### PR TITLE
feature/more-life-cycle-for-nodes

### DIFF
--- a/HumbleEngine.Core.Tests/NodeTreeTests.cs
+++ b/HumbleEngine.Core.Tests/NodeTreeTests.cs
@@ -5,20 +5,27 @@ file class NodeThatAddsChildOnTreeEntered(Node child) : Node
     public override void TreeEntered() => AddChild(child);
 }
 
-file class OrderTrackingNode(List<Node> callOrder) : Node
+file class OrderTrackingNode(List<Node> callOrder, string trackedCallback) : Node
 {
-    public override void TreeExiting() => callOrder.Add(this);
+    public override void TreeEntered() { if (trackedCallback == nameof(TreeEntered)) callOrder.Add(this); }
+    public override void Ready() { if (trackedCallback == nameof(Ready)) callOrder.Add(this); }
+    public override void Unready() { if (trackedCallback == nameof(Unready)) callOrder.Add(this); }
+    public override void TreeExiting() { if (trackedCallback == nameof(TreeExiting)) callOrder.Add(this); }
 }
 
 file class TrackingNode : Node
 {
     public bool TreeEnteredCalled { get; private set; }
     public bool TreeExitingCalled { get; private set; }
+    public bool ReadyCalled { get; private set; }
+    public bool UnreadyCalled { get; private set; }
     public double? LastProcessDelta { get; private set; }
     public double? LastPhysicsProcessDelta { get; private set; }
 
     public override void TreeEntered() => TreeEnteredCalled = true;
     public override void TreeExiting() => TreeExitingCalled = true;
+    public override void Ready() => ReadyCalled = true;
+    public override void Unready() => UnreadyCalled = true;
     public override void Process(double delta) => LastProcessDelta = delta;
     public override void PhysicsProcess(double delta) => LastPhysicsProcessDelta = delta;
 }
@@ -60,6 +67,64 @@ public class NodeTreeTests
 
         Assert.That(root.TreeEnteredCalled, Is.True);
         Assert.That(child.TreeEnteredCalled, Is.True);
+    }
+
+    [Test]
+    public void Constructor_CallsReadyOnAllNodes()
+    {
+        var root = new TrackingNode();
+        var child = new TrackingNode();
+        root.AddChild(child);
+
+        new NodeTree(root);
+
+        Assert.That(root.ReadyCalled, Is.True);
+        Assert.That(child.ReadyCalled, Is.True);
+    }
+
+    [Test]
+    public void RemoveChild_AfterFlush_CallsUnreadyOnRemovedNodes()
+    {
+        var root = new Node();
+        var child = new TrackingNode();
+        root.AddChild(child);
+        var tree = new NodeTree(root);
+
+        root.RemoveChild(child);
+        tree.Process(0);
+
+        Assert.That(child.UnreadyCalled, Is.True);
+    }
+
+    [Test]
+    public void RemoveChild_AfterFlush_CallsUnreadyInPrefixOrder()
+    {
+        var callOrder = new List<Node>();
+        var root = new OrderTrackingNode(callOrder, nameof(Node.Unready));
+        var a = new OrderTrackingNode(callOrder, nameof(Node.Unready));
+        var c = new OrderTrackingNode(callOrder, nameof(Node.Unready));
+        a.AddChild(c);
+        root.AddChild(a);
+        var tree = new NodeTree(root);
+
+        root.RemoveChild(a);
+        tree.Process(0);
+
+        // Préfixe de a : a, c → Unready dans cet ordre
+        Assert.That(callOrder, Is.EqualTo(new[] { a, c }));
+    }
+
+    [Test]
+    public void AddChild_AfterFlush_CallsReadyOnNewNode()
+    {
+        var root = new Node();
+        var tree = new NodeTree(root);
+        var child = new TrackingNode();
+
+        root.AddChild(child);
+        tree.Process(0);
+
+        Assert.That(child.ReadyCalled, Is.True);
     }
 
     [Test]
@@ -107,13 +172,29 @@ public class NodeTreeTests
     }
 
     [Test]
+    public void Constructor_CallsReadyInReversePrefixOrder()
+    {
+        var callOrder = new List<Node>();
+        var root = new OrderTrackingNode(callOrder, nameof(Node.Ready));
+        var a = new OrderTrackingNode(callOrder, nameof(Node.Ready));
+        var c = new OrderTrackingNode(callOrder, nameof(Node.Ready));
+        a.AddChild(c);
+        root.AddChild(a);
+
+        new NodeTree(root);
+
+        // Préfixe de root : root, a, c → inverse : c, a, root
+        Assert.That(callOrder, Is.EqualTo(new[] { c, a, root }));
+    }
+
+    [Test]
     public void RemoveChild_AfterFlush_CallsTreeExitingInReversePrefixOrder()
     {
         var callOrder = new List<Node>();
-        var root = new OrderTrackingNode(callOrder);
-        var a = new OrderTrackingNode(callOrder);
-        var b = new OrderTrackingNode(callOrder);
-        var c = new OrderTrackingNode(callOrder);
+        var root = new OrderTrackingNode(callOrder, nameof(Node.TreeExiting));
+        var a = new OrderTrackingNode(callOrder, nameof(Node.TreeExiting));
+        var b = new OrderTrackingNode(callOrder, nameof(Node.TreeExiting));
+        var c = new OrderTrackingNode(callOrder, nameof(Node.TreeExiting));
         a.AddChild(c);
         root.AddChild(a);
         root.AddChild(b);

--- a/HumbleEngine.Core/Node.cs
+++ b/HumbleEngine.Core/Node.cs
@@ -222,7 +222,7 @@ public class Node
     /// </summary>
     /// <param name="delta">The elapsed time in seconds since the previous frame.</param>
     public virtual void Process(double delta){}
-
+    
     /// <summary>
     /// Called every physics tick. Override to implement physics-related logic.
     /// </summary>
@@ -234,7 +234,13 @@ public class Node
     /// logic that depends on being inside a tree.
     /// </summary>
     public virtual void TreeEntered(){}
-
+    
+    
+    public virtual void Ready(){}
+    
+    
+    public virtual void Unready(){}
+    
     /// <summary>
     /// Called when this node is about to leave its <see cref="NodeTree"/>. Override to run
     /// cleanup logic before the node is detached from the tree.

--- a/HumbleEngine.Core/Node.cs
+++ b/HumbleEngine.Core/Node.cs
@@ -230,21 +230,49 @@ public class Node
     public virtual void PhysicsProcess(double delta){}
 
     /// <summary>
-    /// Called when this node enters an <see cref="NodeTree"/>. Override to run initialization
-    /// logic that depends on being inside a tree.
+    /// Called when this node enters a <see cref="NodeTree"/>, before its children have entered.
+    /// Override to run initialization logic that depends on being inside a tree but does not
+    /// require children to be ready yet.
     /// </summary>
+    /// <remarks>
+    /// At the time this is called, children may not yet have entered the tree.
+    /// Use <see cref="Ready"/> instead if your initialization depends on children being ready.
+    /// </remarks>
     public virtual void TreeEntered(){}
-    
-    
-    public virtual void Ready(){}
-    
-    
-    public virtual void Unready(){}
-    
+
     /// <summary>
-    /// Called when this node is about to leave its <see cref="NodeTree"/>. Override to run
-    /// cleanup logic before the node is detached from the tree.
+    /// Called after this node and all of its children have entered the tree and received
+    /// <see cref="TreeEntered"/>. Override to run initialization logic that requires
+    /// the entire subtree to be ready.
     /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="TreeEntered"/>, <see cref="Ready"/> is guaranteed to be called
+    /// after all children in the subtree have already received their own <see cref="Ready"/>.
+    /// </remarks>
+    public virtual void Ready(){}
+
+    /// <summary>
+    /// Called when this node is about to leave its <see cref="NodeTree"/>, before its children
+    /// have been unreadied. Override to run cleanup logic that must happen before children are
+    /// invalidated.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Unready"/> is the symmetric counterpart of <see cref="Ready"/>.
+    /// Unlike <see cref="TreeExiting"/>, which is called after children have exited,
+    /// <see cref="Unready"/> is called before children receive their own <see cref="Unready"/>.
+    /// </remarks>
+    public virtual void Unready(){}
+
+    /// <summary>
+    /// Called when this node is about to leave its <see cref="NodeTree"/>, after all of its
+    /// children have already received <see cref="TreeExiting"/>. Override to run cleanup logic
+    /// once the entire subtree has exited.
+    /// </summary>
+    /// <remarks>
+    /// At the time this is called, children have already received <see cref="TreeExiting"/>
+    /// and are about to be detached from the tree.
+    /// Use <see cref="Unready"/> instead if your cleanup must happen before children are invalidated.
+    /// </remarks>
     public virtual void TreeExiting(){}
     
     #endregion

--- a/HumbleEngine.Core/NodeTree.cs
+++ b/HumbleEngine.Core/NodeTree.cs
@@ -86,6 +86,10 @@ public class NodeTree
         {
             node.TreeEntered();
         });
+        root.GetSubtreeInReversePrefixOrder().ForEach(node =>
+        {
+            node.Ready();
+        });
     }
 
     /// <summary>
@@ -99,6 +103,10 @@ public class NodeTree
         root.GetSubtreeInReversePrefixOrder().ForEach(node =>
         {
             node.TreeExiting();
+        });
+        root.GetSubtreeInPrefixOrder().ForEach(node =>
+        {
+            node.Unready();
         });
         root.GetSubtreeInReversePrefixOrder().ForEach(node =>
         {

--- a/HumbleEngine.Core/NodeTree.cs
+++ b/HumbleEngine.Core/NodeTree.cs
@@ -9,6 +9,32 @@ namespace HumbleEngine.Core;
 /// Structural changes (adding/removing children) that occur while nodes are attached to the tree
 /// are queued as <see cref="NodeTreeCommand"/> instances and executed at the end of each
 /// <see cref="Process"/> or <see cref="PhysicsProcess"/> call via <see cref="FlushCommands"/>.
+/// <para>
+/// The following table summarizes the order in which lifecycle callbacks are invoked
+/// when a subtree is registered or unregistered:
+/// </para>
+/// <list type="table">
+///   <listheader>
+///     <term>Callback</term>
+///     <description>Order</description>
+///   </listheader>
+///   <item>
+///     <term><see cref="Node.TreeEntered"/></term>
+///     <description>Prefix — parent before children</description>
+///   </item>
+///   <item>
+///     <term><see cref="Node.Ready"/></term>
+///     <description>Reverse prefix — children before parent</description>
+///   </item>
+///   <item>
+///     <term><see cref="Node.Unready"/></term>
+///     <description>Prefix — parent before children</description>
+///   </item>
+///   <item>
+///     <term><see cref="Node.TreeExiting"/></term>
+///     <description>Reverse prefix — children before parent</description>
+///   </item>
+/// </list>
 /// </remarks>
 public class NodeTree
 {
@@ -72,8 +98,12 @@ public class NodeTree
 
     /// <summary>
     /// Registers all nodes in <paramref name="root"/>'s subtree into this tree.
-    /// Sets their <see cref="Node.Tree"/> property, then calls <see cref="Node.TreeEntered"/>
-    /// on each node in prefix order.
+    /// Proceeds in three passes:
+    /// <list type="number">
+    ///   <item><description>Sets <see cref="Node.Tree"/> on all nodes in prefix order.</description></item>
+    ///   <item><description>Calls <see cref="Node.TreeEntered"/> on all nodes in prefix order (parent before children).</description></item>
+    ///   <item><description>Calls <see cref="Node.Ready"/> on all nodes in reverse prefix order (children before parent).</description></item>
+    /// </list>
     /// </summary>
     /// <param name="root">The root of the subtree to register.</param>
     internal void RegisterSubtree(Node root)
@@ -94,19 +124,23 @@ public class NodeTree
 
     /// <summary>
     /// Unregisters all nodes in <paramref name="root"/>'s subtree from this tree.
-    /// Calls <see cref="Node.TreeExiting"/> on each node in reverse prefix order (children before
-    /// their parent), then sets their <see cref="Node.Tree"/> property to <c>null</c>.
+    /// Proceeds in three passes:
+    /// <list type="number">
+    ///   <item><description>Calls <see cref="Node.Unready"/> on all nodes in prefix order (parent before children).</description></item>
+    ///   <item><description>Calls <see cref="Node.TreeExiting"/> on all nodes in reverse prefix order (children before parent).</description></item>
+    ///   <item><description>Sets <see cref="Node.Tree"/> to <c>null</c> on all nodes in reverse prefix order.</description></item>
+    /// </list>
     /// </summary>
     /// <param name="root">The root of the subtree to unregister.</param>
     internal void UnregisterSubtree(Node root)
     {
-        root.GetSubtreeInReversePrefixOrder().ForEach(node =>
-        {
-            node.TreeExiting();
-        });
         root.GetSubtreeInPrefixOrder().ForEach(node =>
         {
             node.Unready();
+        });
+        root.GetSubtreeInReversePrefixOrder().ForEach(node =>
+        {
+            node.TreeExiting();
         });
         root.GetSubtreeInReversePrefixOrder().ForEach(node =>
         {


### PR DESCRIPTION
Add new life cycle method :

- A method that is called on a node after it has be called on all its children when it entered the tree. (Similar to Ready in Godot)

- A method that is called on a node before all its children when its about to leave the tree. (The opposite of Ready kind of)