### PR TITLE
Phase 2 — Premier rendu + extensions Phase 1

### DIFF
--- a/HumbleEngine.Sample/HumbleEngine.Sample.csproj
+++ b/HumbleEngine.Sample/HumbleEngine.Sample.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\HumbleEngine\HumbleEngine.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/HumbleEngine.Sample/Program.cs
+++ b/HumbleEngine.Sample/Program.cs
@@ -1,0 +1,13 @@
+using HumbleEngine;
+using SkiaSharp;
+
+using var app = new Application("HumbleEngine — Phase 2", 800, 600);
+
+app.Root = new Label
+{
+    Text     = { Value = "Hello, HumbleEngine!" },
+    FontSize = { Value = 32f },
+    Color    = { Value = SKColors.DarkSlateBlue }
+};
+
+app.Run();

--- a/HumbleEngine.Tests/Core/ReactiveCollectionTests.cs
+++ b/HumbleEngine.Tests/Core/ReactiveCollectionTests.cs
@@ -61,7 +61,7 @@ public class ReactiveCollectionTests
         col.Add(1);
         col.Add(2);
         bool resetFired = false;
-        col.Reset.Connect(() => resetFired = true);
+        col.Cleared.Connect(() => resetFired = true);
 
         col.Clear();
 

--- a/HumbleEngine.Tests/Core/ReactiveCollectionTests.cs
+++ b/HumbleEngine.Tests/Core/ReactiveCollectionTests.cs
@@ -9,13 +9,14 @@ public class ReactiveCollectionTests
     public void Add_EmitsItemAdded()
     {
         var col = new ReactiveCollection<string>();
-        (int index, string item) received = (-1, "");
-        col.ItemAdded.Connect(e => received = e);
+        int receivedIndex = -1;
+        string receivedItem = "";
+        col.ItemAdded.Connect((index, item) => { receivedIndex = index; receivedItem = item; });
 
         col.Add("hello");
 
-        Assert.That(received.index, Is.EqualTo(0));
-        Assert.That(received.item, Is.EqualTo("hello"));
+        Assert.That(receivedIndex, Is.EqualTo(0));
+        Assert.That(receivedItem, Is.EqualTo("hello"));
     }
 
     [Test]
@@ -34,13 +35,14 @@ public class ReactiveCollectionTests
         var col = new ReactiveCollection<string>();
         col.Add("a");
         col.Add("b");
-        (int index, string item) received = (-1, "");
-        col.ItemRemoved.Connect(e => received = e);
+        int receivedIndex = -1;
+        string receivedItem = "";
+        col.ItemRemoved.Connect((index, item) => { receivedIndex = index; receivedItem = item; });
 
         col.RemoveAt(0);
 
-        Assert.That(received.index, Is.EqualTo(0));
-        Assert.That(received.item, Is.EqualTo("a"));
+        Assert.That(receivedIndex, Is.EqualTo(0));
+        Assert.That(receivedItem, Is.EqualTo("a"));
     }
 
     [Test]
@@ -55,17 +57,17 @@ public class ReactiveCollectionTests
     }
 
     [Test]
-    public void Clear_EmitsReset()
+    public void Clear_EmitsClearedSignal()
     {
         var col = new ReactiveCollection<int>();
         col.Add(1);
         col.Add(2);
-        bool resetFired = false;
-        col.Cleared.Connect(() => resetFired = true);
+        bool clearedFired = false;
+        col.Cleared.Connect(() => clearedFired = true);
 
         col.Clear();
 
-        Assert.That(resetFired, Is.True);
+        Assert.That(clearedFired, Is.True);
         Assert.That(col.Count, Is.EqualTo(0));
     }
 
@@ -85,13 +87,14 @@ public class ReactiveCollectionTests
         var col = new ReactiveCollection<string>();
         col.Add("a");
         col.Add("c");
-        (int index, string item) received = (-1, "");
-        col.ItemAdded.Connect(e => received = e);
+        int receivedIndex = -1;
+        string receivedItem = "";
+        col.ItemAdded.Connect((index, item) => { receivedIndex = index; receivedItem = item; });
 
         col.Insert(1, "b");
 
-        Assert.That(received.index, Is.EqualTo(1));
-        Assert.That(received.item, Is.EqualTo("b"));
+        Assert.That(receivedIndex, Is.EqualTo(1));
+        Assert.That(receivedItem, Is.EqualTo("b"));
         Assert.That(col[1], Is.EqualTo("b"));
     }
 

--- a/HumbleEngine.sln
+++ b/HumbleEngine.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HumbleEngine", "HumbleEngin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HumbleEngine.Tests", "HumbleEngine.Tests\HumbleEngine.Tests.csproj", "{216E48AB-E1D8-45B3-A32A-97C1A1260771}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HumbleEngine.Sample", "HumbleEngine.Sample\HumbleEngine.Sample.csproj", "{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,18 @@ Global
 		{216E48AB-E1D8-45B3-A32A-97C1A1260771}.Release|x64.Build.0 = Release|Any CPU
 		{216E48AB-E1D8-45B3-A32A-97C1A1260771}.Release|x86.ActiveCfg = Release|Any CPU
 		{216E48AB-E1D8-45B3-A32A-97C1A1260771}.Release|x86.Build.0 = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|x64.Build.0 = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{6356BE6B-B945-4C64-BC29-ED22F4FC65E9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HumbleEngine/Application.cs
+++ b/HumbleEngine/Application.cs
@@ -1,0 +1,93 @@
+using Silk.NET.Maths;
+using Silk.NET.Windowing;
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public sealed class Application : IDisposable
+{
+    private readonly IWindow _window;
+    private GRContext?   _grContext;
+    private SKSurface?   _surface;
+
+    public Node? Root { get; set; }
+
+    public Application(string title = "HumbleEngine", int width = 800, int height = 600)
+    {
+        var options = WindowOptions.Default;
+        options.Title  = title;
+        options.Size   = new Vector2D<int>(width, height);
+        options.PreferredStencilBufferBits = 8;
+
+        _window = Window.Create(options);
+        _window.Load    += OnLoad;
+        _window.Update  += OnUpdate;
+        _window.Render  += OnRender;
+        _window.Resize  += OnResize;
+        _window.Closing += OnClosing;
+    }
+
+    public void Run() => _window.Run();
+
+    private void OnLoad()
+    {
+        var glInterface = GRGlInterface.Create(name =>
+        {
+            _window.GLContext!.TryGetProcAddress(name, out var addr);
+            return addr;
+        });
+
+        _grContext = GRContext.CreateGl(glInterface);
+        CreateSurface();
+
+        if (Root is null) return;
+        Root.Init();
+        Root.MarkLayoutDirty();
+    }
+
+    private void CreateSurface()
+    {
+        _surface?.Dispose();
+
+        var (w, h)     = (_window.Size.X, _window.Size.Y);
+        var fbInfo     = new GRGlFramebufferInfo(0, 0x8058); // GL_RGBA8
+        var renderTarget = new GRBackendRenderTarget(w, h, 0, 8, fbInfo);
+
+        _surface = SKSurface.Create(
+            _grContext,
+            renderTarget,
+            GRSurfaceOrigin.BottomLeft,
+            SKColorType.Rgba8888);
+    }
+
+    private void OnUpdate(double delta) => Root?.Update((float)delta);
+
+    private void OnRender(double delta)
+    {
+        if (Root is null || _surface is null) return;
+
+        var canvas = _surface.Canvas;
+
+        Root.Layout(new Size(_window.Size.X, _window.Size.Y));
+        canvas.Clear(SKColors.White);
+        Root.Paint(canvas);
+        canvas.Flush();
+
+        Root.ClearDirty();
+    }
+
+    private void OnResize(Vector2D<int> _)
+    {
+        CreateSurface();
+        Root?.MarkLayoutDirty();
+    }
+
+    private void OnClosing() => Root?.Dispose();
+
+    public void Dispose()
+    {
+        _surface?.Dispose();
+        _grContext?.Dispose();
+        _window.Dispose();
+    }
+}

--- a/HumbleEngine/Application.cs
+++ b/HumbleEngine/Application.cs
@@ -7,19 +7,22 @@ namespace HumbleEngine;
 public sealed class Application : IDisposable
 {
     private readonly IWindow _window;
-    private GRContext?   _grContext;
-    private SKSurface?   _surface;
+    private GRContext?  _grContext;  // contexte GPU SkiaSharp — wraps le contexte OpenGL
+    private SKSurface?  _surface;   // surface de rendu liée au framebuffer de la fenêtre
 
     public Node? Root { get; set; }
 
     public Application(string title = "HumbleEngine", int width = 800, int height = 600)
     {
         var options = WindowOptions.Default;
+        // WindowOptions.Default crée une fenêtre OpenGL 3.3 core profile
         options.Title  = title;
         options.Size   = new Vector2D<int>(width, height);
+        // SkiaSharp utilise le stencil buffer pour le clipping — 8 bits requis
         options.PreferredStencilBufferBits = 8;
 
         _window = Window.Create(options);
+        // Les delegates sont enregistrés ici mais appelés plus tard par Silk.NET
         _window.Load    += OnLoad;
         _window.Update  += OnUpdate;
         _window.Render  += OnRender;
@@ -27,37 +30,58 @@ public sealed class Application : IDisposable
         _window.Closing += OnClosing;
     }
 
+    // Démarre la boucle événementielle — bloque jusqu'à la fermeture de la fenêtre
     public void Run() => _window.Run();
 
     private void OnLoad()
     {
-        var glInterface = GRGlInterface.Create(name =>
-        {
-            _window.GLContext!.TryGetProcAddress(name, out var addr);
-            return addr;
-        });
+        // À ce stade, Silk.NET a créé la fenêtre et rendu le contexte OpenGL courant.
+        // GRGlInterface.Create() sans argument détecte automatiquement le contexte GL
+        // courant — plus fiable que passer un lambda de proc addresses.
+        var glInterface = GRGlInterface.Create();
 
+        if (glInterface is null)
+            throw new InvalidOperationException(
+                "SkiaSharp n'a pas pu créer l'interface OpenGL. " +
+                "Vérifiez que OpenGL 3.3+ est disponible.");
+
+        // GRContext est le pont entre SkiaSharp et le GPU.
+        // Il cache les shaders, les textures et gère les ressources GPU.
         _grContext = GRContext.CreateGl(glInterface);
+
+        if (_grContext is null)
+            throw new InvalidOperationException(
+                "SkiaSharp n'a pas pu créer le contexte GPU (GRContext).");
+
         CreateSurface();
 
-        if (Root is null) return;
-        Root.Init();
-        Root.MarkLayoutDirty();
+        Root?.Init();
+        Root?.MarkLayoutDirty();
     }
 
     private void CreateSurface()
     {
         _surface?.Dispose();
 
-        var (w, h)     = (_window.Size.X, _window.Size.Y);
-        var fbInfo     = new GRGlFramebufferInfo(0, 0x8058); // GL_RGBA8
-        var renderTarget = new GRBackendRenderTarget(w, h, 0, 8, fbInfo);
+        var (w, h) = (_window.FramebufferSize.X, _window.FramebufferSize.Y);
 
-        _surface = SKSurface.Create(
-            _grContext,
-            renderTarget,
-            GRSurfaceOrigin.BottomLeft,
-            SKColorType.Rgba8888);
+        // GRGlFramebufferInfo décrit le framebuffer OpenGL cible.
+        // 0 = FBO par défaut (le framebuffer de la fenêtre).
+        // 0x8058 = GL_RGBA8, le format de pixel du framebuffer.
+        var fbInfo = new GRGlFramebufferInfo(fboId: 0, format: 0x8058);
+
+        // GRBackendRenderTarget représente la surface GPU à laquelle SkiaSharp va écrire.
+        // sampleCount: 0 = pas de multisampling, stencilBits: 8 = pour le clipping.
+        var renderTarget = new GRBackendRenderTarget(w, h, sampleCount: 0, stencilBits: 8, fbInfo);
+
+        // SKSurface est la surface de dessin. GRSurfaceOrigin.BottomLeft car OpenGL
+        // a l'origine en bas à gauche, contrairement à SkiaSharp (haut à gauche) —
+        // cette option compense le flip vertical automatiquement.
+        _surface = SKSurface.Create(_grContext, renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
+
+        if (_surface is null)
+            throw new InvalidOperationException(
+                "SkiaSharp n'a pas pu créer la surface de rendu (SKSurface).");
     }
 
     private void OnUpdate(double delta) => Root?.Update((float)delta);
@@ -68,9 +92,14 @@ public sealed class Application : IDisposable
 
         var canvas = _surface.Canvas;
 
+        // Layout : calcule les positions et tailles de tous les Nodes
         Root.Layout(new Size(_window.Size.X, _window.Size.Y));
+
+        // Efface le framebuffer puis demande à chaque Node de se dessiner
         canvas.Clear(SKColors.White);
         Root.Paint(canvas);
+
+        // Flush soumet les commandes SkiaSharp au driver OpenGL
         canvas.Flush();
 
         Root.ClearDirty();
@@ -78,6 +107,8 @@ public sealed class Application : IDisposable
 
     private void OnResize(Vector2D<int> _)
     {
+        // La taille du framebuffer a changé — la surface doit être recrée
+        // pour correspondre aux nouvelles dimensions.
         CreateSurface();
         Root?.MarkLayoutDirty();
     }

--- a/HumbleEngine/Core/IReactiveCollection.cs
+++ b/HumbleEngine/Core/IReactiveCollection.cs
@@ -1,0 +1,6 @@
+namespace HumbleEngine;
+
+public interface IReactiveCollection<T> : IReadOnlyReactiveCollection<T>, IReactiveProperty<IReadOnlyList<T>>, IList<T>
+{
+    
+}

--- a/HumbleEngine/Core/IReactiveProperty.cs
+++ b/HumbleEngine/Core/IReactiveProperty.cs
@@ -1,0 +1,10 @@
+namespace HumbleEngine;
+
+public interface IReactiveProperty<T> : IReadOnlyReactiveProperty<T>
+{
+    public new T Value
+    {
+        get;
+        set;
+    }
+}

--- a/HumbleEngine/Core/IReadOnlyReactiveCollection.cs
+++ b/HumbleEngine/Core/IReadOnlyReactiveCollection.cs
@@ -1,0 +1,9 @@
+namespace HumbleEngine;
+
+public interface IReadOnlyReactiveCollection<out T> : IReadOnlyReactiveProperty<IReadOnlyList<T>>
+{
+    public ISignal<int, T> ItemAdded { get; }
+    public ISignal<int, T> ItemRemoved{ get; }
+    public ISignal                      Cleared   { get; }
+    public ISignal                      Changed   { get; }
+}

--- a/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
+++ b/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
@@ -1,0 +1,6 @@
+namespace HumbleEngine;
+
+public interface IReadOnlyReactiveProperty<T> : ISignal<T>
+{
+    public T Value { get; }
+}

--- a/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
+++ b/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
@@ -1,6 +1,6 @@
 namespace HumbleEngine;
 
-public interface IReadOnlyReactiveProperty<T> : ISignal<T>
+public interface IReadOnlyReactiveProperty<out T> : ISignal<T>
 {
     public T Value { get; }
 }

--- a/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
+++ b/HumbleEngine/Core/IReadOnlyReactiveProperty.cs
@@ -2,5 +2,6 @@ namespace HumbleEngine;
 
 public interface IReadOnlyReactiveProperty<out T> : ISignal<T>
 {
+    public ISignal<T, T> Reaffected { get; }
     public T Value { get; }
 }

--- a/HumbleEngine/Core/Node.cs
+++ b/HumbleEngine/Core/Node.cs
@@ -1,3 +1,5 @@
+using SkiaSharp;
+
 namespace HumbleEngine;
 
 public abstract class Node
@@ -50,6 +52,17 @@ public abstract class Node
     {
         foreach (var child in _children)
             child.Layout(available);
+    }
+
+    public virtual void Paint(SKCanvas canvas)
+    {
+        foreach (var child in _children)
+        {
+            canvas.Save();
+            canvas.Translate(child.ComputedBounds.X, child.ComputedBounds.Y);
+            child.Paint(canvas);
+            canvas.Restore();
+        }
     }
 
     public virtual void Dispose()

--- a/HumbleEngine/Core/ReactiveCollection.cs
+++ b/HumbleEngine/Core/ReactiveCollection.cs
@@ -8,26 +8,31 @@ public class ReactiveCollection<T> : IReadOnlyList<T>
 
     private readonly MutableSignal<(int Index, T Item)> _itemAdded   = new();
     private readonly MutableSignal<(int Index, T Item)> _itemRemoved = new();
-    private readonly MutableSignal                      _reset        = new();
+    private readonly MutableSignal                      _cleared      = new();
     private readonly MutableSignal                      _changed      = new();
 
     public Signal<(int Index, T Item)> ItemAdded   => _itemAdded.Signal;
     public Signal<(int Index, T Item)> ItemRemoved => _itemRemoved.Signal;
-    public Signal                      Reset        => _reset.Signal;
+    public Signal                      Cleared      => _cleared.Signal;
     public Signal                      Changed      => _changed.Signal;
+
+    public ReactiveCollection()
+    {
+        ItemAdded.Connect(_ => _changed.Emit());
+        ItemRemoved.Connect(_ => _changed.Emit());
+        Cleared.Connect(() => _changed.Emit());
+    }
 
     public void Add(T item)
     {
         _list.Add(item);
         _itemAdded.Emit((_list.Count - 1, item));
-        _changed.Emit();
     }
 
     public void Insert(int index, T item)
     {
         _list.Insert(index, item);
         _itemAdded.Emit((index, item));
-        _changed.Emit();
     }
 
     public bool Remove(T item)
@@ -43,14 +48,12 @@ public class ReactiveCollection<T> : IReadOnlyList<T>
         var item = _list[index];
         _list.RemoveAt(index);
         _itemRemoved.Emit((index, item));
-        _changed.Emit();
     }
 
     public void Clear()
     {
         _list.Clear();
-        _reset.Emit();
-        _changed.Emit();
+        _cleared.Emit();
     }
 
     public T this[int index] => _list[index];

--- a/HumbleEngine/Core/ReactiveCollection.cs
+++ b/HumbleEngine/Core/ReactiveCollection.cs
@@ -2,42 +2,87 @@ using System.Collections;
 
 namespace HumbleEngine;
 
-public class ReactiveCollection<T> : IReadOnlyList<T>
+public class ReactiveCollection<T> : IReactiveCollection<T>
 {
-    private readonly List<T> _list = new();
+    private readonly ReactiveProperty<List<T>> _innerList = new([]);
+    public void Connect(Action<IReadOnlyList<T>> listener) => _innerList.Connect(listener);
+    public void Disconnect(Action<IReadOnlyList<T>> listener) => _innerList.Disconnect(listener);
 
-    private readonly MutableSignal<(int Index, T Item)> _itemAdded   = new();
-    private readonly MutableSignal<(int Index, T Item)> _itemRemoved = new();
+    public ISignal<IReadOnlyList<T>, IReadOnlyList<T>> Reaffected => _innerList.Reaffected;
+
+    public IReadOnlyList<T> Value
+    {
+        get => _innerList.Value;
+        set => _innerList.Value = value as List<T> ?? value.ToList();
+    }
+
+    private readonly MutableSignal<int, T> _itemAdded   = new();
+    private readonly MutableSignal<int, T> _itemRemoved = new();
     private readonly MutableSignal                      _cleared      = new();
     private readonly MutableSignal                      _changed      = new();
 
-    public Signal<(int Index, T Item)> ItemAdded   => _itemAdded.Signal;
-    public Signal<(int Index, T Item)> ItemRemoved => _itemRemoved.Signal;
-    public Signal                      Cleared      => _cleared.Signal;
-    public Signal                      Changed      => _changed.Signal;
+    public ISignal<int, T> ItemAdded   => _itemAdded.Signal;
+    public ISignal<int, T> ItemRemoved => _itemRemoved.Signal;
+    public ISignal                      Cleared      => _cleared.Signal;
+    public ISignal                      Changed      => _changed.Signal;
 
     public ReactiveCollection()
     {
-        ItemAdded.Connect(_ => _changed.Emit());
-        ItemRemoved.Connect(_ => _changed.Emit());
-        Cleared.Connect(() => _changed.Emit());
+        ItemAdded.Connect( EmitChanged );
+        ItemRemoved.Connect( EmitChanged );
+        Cleared.Connect( EmitChanged );
+        Reaffected.Connect((oldList, newList) =>
+        {
+            ItemAdded.Disconnect( EmitChanged );
+            ItemRemoved.Disconnect( EmitChanged );
+            
+            if (oldList != null)
+            {
+                for (int i = 0; i < oldList.Count; i++)
+                {
+                    _itemRemoved.Emit(i, oldList[i]);
+                }
+            }
+
+            if (newList != null)
+            {
+                for (int i = 0; i < newList.Count; i++)
+                {
+                    _itemAdded.Emit(i, newList[i]);
+                }
+            }
+            
+            ItemAdded.Connect( EmitChanged );
+            ItemRemoved.Connect( EmitChanged );
+            EmitChanged();
+        });
     }
 
     public void Add(T item)
     {
-        _list.Add(item);
-        _itemAdded.Emit((_list.Count - 1, item));
+        _innerList.Value.Add(item);
+        _itemAdded.Emit(_innerList.Value.Count - 1, item);
+    }
+
+    public int IndexOf(T item)
+    {
+        return _innerList.Value.IndexOf(item);
     }
 
     public void Insert(int index, T item)
     {
-        _list.Insert(index, item);
-        _itemAdded.Emit((index, item));
+        _innerList.Value.Insert(index, item);
+        _itemAdded.Emit(index, item);
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        _innerList.Value.CopyTo(array, arrayIndex);
     }
 
     public bool Remove(T item)
     {
-        int index = _list.IndexOf(item);
+        int index = _innerList.Value.IndexOf(item);
         if (index < 0) return false;
         RemoveAt(index);
         return true;
@@ -45,20 +90,39 @@ public class ReactiveCollection<T> : IReadOnlyList<T>
 
     public void RemoveAt(int index)
     {
-        var item = _list[index];
-        _list.RemoveAt(index);
-        _itemRemoved.Emit((index, item));
+        var item = _innerList.Value[index];
+        _innerList.Value.RemoveAt(index);
+        _itemRemoved.Emit(index, item);
     }
 
     public void Clear()
     {
-        _list.Clear();
+        _innerList.Value.Clear();
         _cleared.Emit();
     }
 
-    public T this[int index] => _list[index];
-    public int Count         => _list.Count;
+    public bool Contains(T item)
+    {
+        return _innerList.Value.Contains(item);
+    }
 
-    public IEnumerator<T> GetEnumerator()   => _list.GetEnumerator();
+    public T this[int index]
+    {
+        get => _innerList.Value[index];
+        set
+        {
+            RemoveAt(index);
+            Insert(index, value);
+        }
+    }
+
+    public int Count         => _innerList.Value.Count;
+    public bool IsReadOnly => (_innerList.Value as IList<T>).IsReadOnly;
+
+    public IEnumerator<T> GetEnumerator()   => _innerList.Value.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void EmitChanged() => _changed.Emit();
+    private void EmitChanged<T1, T2>(T1 a, T2 b) => EmitChanged();
+    
 }

--- a/HumbleEngine/Core/ReactiveProperty.cs
+++ b/HumbleEngine/Core/ReactiveProperty.cs
@@ -2,26 +2,26 @@ namespace HumbleEngine;
 
 public class ReactiveProperty<T> : IReactiveProperty<T>
 {
-    private T _value;
+    protected T ProtectedValue;
     private readonly MutableSignal<T> _signal = new();
     private readonly MutableSignal<T, T> _reaffected = new();
     // TODO : Add doc to explain that first param is oldValue and second is newValue...
     public ISignal<T, T> Reaffected => _reaffected.Signal;
 
-    public ReactiveProperty(T initial) => _value = initial;
+    public ReactiveProperty(T initial = default) => ProtectedValue = initial;
     
     public static implicit operator T(ReactiveProperty<T> value) => value.Value;
 
     public T Value
     {
-        get => _value;
+        get => ProtectedValue;
         set
         {
-            if (EqualityComparer<T>.Default.Equals(_value, value)) 
+            if (EqualityComparer<T>.Default.Equals(ProtectedValue, value)) 
                 return;
             
-            T oldValue = _value;
-            _value = value;
+            T oldValue = ProtectedValue;
+            ProtectedValue = value;
             _signal.Emit(value);
             _reaffected.Emit(oldValue, value);
         }

--- a/HumbleEngine/Core/ReactiveProperty.cs
+++ b/HumbleEngine/Core/ReactiveProperty.cs
@@ -6,6 +6,8 @@ public class ReactiveProperty<T> : ISignal<T>
     private readonly MutableSignal<T> _signal = new();
 
     public ReactiveProperty(T initial) => _value = initial;
+    
+    public static implicit operator T(ReactiveProperty<T> value) => value.Value;
 
     public T Value
     {

--- a/HumbleEngine/Core/ReactiveProperty.cs
+++ b/HumbleEngine/Core/ReactiveProperty.cs
@@ -4,8 +4,9 @@ public class ReactiveProperty<T> : IReactiveProperty<T>
 {
     private T _value;
     private readonly MutableSignal<T> _signal = new();
-    private readonly MutableSignal<(T oldValue, T newValue)> _reaffected = new();
-    public Signal<(T oldValue, T newValue)> Reaffected => _reaffected.Signal;
+    private readonly MutableSignal<T, T> _reaffected = new();
+    // TODO : Add doc to explain that first param is oldValue and second is newValue...
+    public ISignal<T, T> Reaffected => _reaffected.Signal;
 
     public ReactiveProperty(T initial) => _value = initial;
     
@@ -22,7 +23,7 @@ public class ReactiveProperty<T> : IReactiveProperty<T>
             T oldValue = _value;
             _value = value;
             _signal.Emit(value);
-            _reaffected.Emit((oldValue, value));
+            _reaffected.Emit(oldValue, value);
         }
     }
 

--- a/HumbleEngine/Core/ReactiveProperty.cs
+++ b/HumbleEngine/Core/ReactiveProperty.cs
@@ -4,6 +4,8 @@ public class ReactiveProperty<T> : IReactiveProperty<T>
 {
     private T _value;
     private readonly MutableSignal<T> _signal = new();
+    private readonly MutableSignal<(T oldValue, T newValue)> _reaffected = new();
+    public Signal<(T oldValue, T newValue)> Reaffected => _reaffected.Signal;
 
     public ReactiveProperty(T initial) => _value = initial;
     
@@ -14,9 +16,13 @@ public class ReactiveProperty<T> : IReactiveProperty<T>
         get => _value;
         set
         {
-            if (EqualityComparer<T>.Default.Equals(_value, value)) return;
+            if (EqualityComparer<T>.Default.Equals(_value, value)) 
+                return;
+            
+            T oldValue = _value;
             _value = value;
             _signal.Emit(value);
+            _reaffected.Emit((oldValue, value));
         }
     }
 

--- a/HumbleEngine/Core/ReactiveProperty.cs
+++ b/HumbleEngine/Core/ReactiveProperty.cs
@@ -1,6 +1,6 @@
 namespace HumbleEngine;
 
-public class ReactiveProperty<T> : ISignal<T>
+public class ReactiveProperty<T> : IReactiveProperty<T>
 {
     private T _value;
     private readonly MutableSignal<T> _signal = new();

--- a/HumbleEngine/Core/ReadOnlyReactiveCollection.cs
+++ b/HumbleEngine/Core/ReadOnlyReactiveCollection.cs
@@ -1,0 +1,33 @@
+namespace HumbleEngine;
+
+public class ReadOnlyReactiveCollection<T> : IReadOnlyReactiveCollection<T>
+{
+    private IReadOnlyReactiveCollection<T> _reactiveCollection;
+
+    public ReadOnlyReactiveCollection(IReactiveCollection<T> reactiveCollection)
+    {
+        _reactiveCollection = reactiveCollection;
+    }
+
+    public void Connect(Action<IReadOnlyList<T>> listener)
+    {
+        _reactiveCollection.Connect(listener);
+    }
+
+    public void Disconnect(Action<IReadOnlyList<T>> listener)
+    {
+        _reactiveCollection.Disconnect(listener);
+    }
+
+    public ISignal<IReadOnlyList<T>, IReadOnlyList<T>> Reaffected => _reactiveCollection.Reaffected;
+
+    public IReadOnlyList<T> Value => _reactiveCollection.Value;
+
+    public ISignal<int, T> ItemAdded => _reactiveCollection.ItemAdded;
+
+    public ISignal<int, T> ItemRemoved => _reactiveCollection.ItemRemoved;
+
+    public ISignal Cleared => _reactiveCollection.Cleared;
+
+    public ISignal Changed => _reactiveCollection.Changed;
+}

--- a/HumbleEngine/Core/ReadOnlyReactiveProperty.cs
+++ b/HumbleEngine/Core/ReadOnlyReactiveProperty.cs
@@ -7,6 +7,8 @@ public class ReadOnlyReactiveProperty<T> : IReadOnlyReactiveProperty<T>
     public ReadOnlyReactiveProperty(ReactiveProperty<T> reactiveProperty)
         => _reactiveProperty = reactiveProperty;
 
+    public ISignal<T, T> Reaffected => _reactiveProperty.Reaffected;
+
     public T Value => _reactiveProperty.Value;
 
     public void Connect(Action<T> listener)

--- a/HumbleEngine/Core/ReadOnlyReactiveProperty.cs
+++ b/HumbleEngine/Core/ReadOnlyReactiveProperty.cs
@@ -1,0 +1,21 @@
+namespace HumbleEngine;
+
+public class ReadOnlyReactiveProperty<T> : IReadOnlyReactiveProperty<T>
+{
+    private readonly ReactiveProperty<T> _reactiveProperty;
+    
+    public ReadOnlyReactiveProperty(ReactiveProperty<T> reactiveProperty)
+        => _reactiveProperty = reactiveProperty;
+
+    public T Value => _reactiveProperty.Value;
+
+    public void Connect(Action<T> listener)
+    {
+        _reactiveProperty.Connect(listener);
+    }
+
+    public void Disconnect(Action<T> listener)
+    {
+        _reactiveProperty.Disconnect(listener);
+    }
+}

--- a/HumbleEngine/Core/Signal.cs
+++ b/HumbleEngine/Core/Signal.cs
@@ -12,6 +12,12 @@ public interface ISignal<out T>
     void Disconnect(Action<T> listener);
 }
 
+public interface ISignal<out T1, out T2>
+{
+    void Connect(Action<T1, T2> listener);
+    void Disconnect(Action<T1, T2> listener);
+}
+
 public sealed class MutableSignal : ISignal
 {
     private readonly List<Action> _listeners = new();
@@ -64,4 +70,31 @@ public sealed class Signal<T> : ISignal<T>
 
     public void Connect(Action<T> listener)    => _owner.Connect(listener);
     public void Disconnect(Action<T> listener) => _owner.Disconnect(listener);
+}
+
+public sealed class MutableSignal<T1, T2> : ISignal<T1, T2>
+{
+    private readonly List<Action<T1, T2>> _listeners = new();
+
+    public Signal<T1, T2> Signal { get; }
+
+    public MutableSignal() => Signal = new Signal<T1, T2>(this);
+
+    public void Emit(T1 value1, T2 value2)
+    {
+        foreach (var l in _listeners.ToArray()) l(value1, value2);
+    }
+
+    public void Connect(Action<T1, T2> listener)    => _listeners.Add(listener);
+    public void Disconnect(Action<T1, T2> listener) => _listeners.Remove(listener);
+}
+
+public sealed class Signal<T1, T2> : ISignal<T1, T2>
+{
+    private readonly MutableSignal<T1, T2> _owner;
+
+    internal Signal(MutableSignal<T1, T2> owner) => _owner = owner;
+
+    public void Connect(Action<T1, T2> listener)    => _owner.Connect(listener);
+    public void Disconnect(Action<T1, T2> listener) => _owner.Disconnect(listener);
 }

--- a/HumbleEngine/Core/Signal.cs
+++ b/HumbleEngine/Core/Signal.cs
@@ -6,7 +6,7 @@ public interface ISignal
     void Disconnect(Action listener);
 }
 
-public interface ISignal<T>
+public interface ISignal<out T>
 {
     void Connect(Action<T> listener);
     void Disconnect(Action<T> listener);

--- a/HumbleEngine/Nodes/Label.cs
+++ b/HumbleEngine/Nodes/Label.cs
@@ -1,0 +1,38 @@
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public class Label : Node
+{
+    public ReactiveProperty<string>  Text     = new("");
+    public ReactiveProperty<SKColor> Color    = new(SKColors.Black);
+    public ReactiveProperty<float>   FontSize = new(16f);
+
+    public override void Init()
+    {
+        base.Init();
+        Text.Connect(_ => MarkPaintDirty());
+        Color.Connect(_ => MarkPaintDirty());
+        FontSize.Connect(_ => MarkLayoutDirty());
+    }
+
+    public override void Layout(Size available)
+    {
+        using var font = new SKFont(SKTypeface.Default, FontSize.Value);
+        var width  = font.MeasureText(Text.Value);
+        var height = font.Metrics.Descent - font.Metrics.Ascent;
+
+        ComputedBounds = new Rect(ComputedBounds.X, ComputedBounds.Y, width, height);
+    }
+
+    public override void Paint(SKCanvas canvas)
+    {
+        if (string.IsNullOrEmpty(Text.Value)) return;
+
+        using var font  = new SKFont(SKTypeface.Default, FontSize.Value);
+        using var paint = new SKPaint { Color = Color.Value, IsAntialias = true };
+
+        // y = -Ascent place le haut du texte à y=0 (origine du ComputedBounds)
+        canvas.DrawText(Text.Value, 0, -font.Metrics.Ascent, font, paint);
+    }
+}

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -173,11 +173,77 @@ public readonly record struct Rect(float X, float Y, float Width, float Height)
 
 ---
 
+---
+
+## Phase 2 — Premier rendu ✅
+
+Branche : `feature/phase-2-rendering`  
+Tests : 46/46 ✅ (Phase 1 inchangés — Phase 2 nécessite GPU)
+
+---
+
+### `Node` — ajout Phase 2
+
+```csharp
+// Nouveau dans Phase 2
+public virtual void Paint(SKCanvas canvas)
+// Propage aux enfants avec Save/Translate/Restore par enfant
+```
+
+---
+
+### `Application` — `HumbleEngine/Application.cs`
+
+```csharp
+public sealed class Application : IDisposable
+{
+    public Node? Root { get; set; }
+    public Application(string title = "HumbleEngine", int width = 800, int height = 600)
+    public void Run()
+    public void Dispose()
+}
+```
+
+**Boucle interne (par frame) :**
+1. `Root.Layout(windowSize)` — recalcule le layout
+2. `canvas.Clear(White)` + `Root.Paint(canvas)` — redessine
+3. `canvas.Flush()` + `Root.ClearDirty()`
+
+**Stack technique :** Silk.NET (fenêtre + contexte OpenGL) + SkiaSharp (rendu GPU via GRContext).
+
+---
+
+### `Label` — `HumbleEngine/Nodes/Label.cs`
+
+```csharp
+public class Label : Node
+{
+    public ReactiveProperty<string>  Text     = new("");
+    public ReactiveProperty<SKColor> Color    = new(SKColors.Black);
+    public ReactiveProperty<float>   FontSize = new(16f);
+
+    // Layout : mesure le texte → ComputedBounds.Width/Height
+    // Paint  : DrawText à l'origine (parent gère la translation)
+}
+```
+
+**Règles :**
+- `Text` / `Color` → `MarkPaintDirty()`
+- `FontSize` → `MarkLayoutDirty()`
+- Le parent est responsable de placer `ComputedBounds.X/Y`
+
+---
+
+### `HumbleEngine.Sample`
+
+Projet console de démonstration. Lance une fenêtre 800×600 avec un `Label`.
+
+---
+
 ## Phases suivantes
 
 | Phase | Contenu | Statut |
 |-------|---------|--------|
-| 2 | `Application`, boucle principale, SkiaSharp, `Label` | ⬜ |
 | 3 | Input system, hit testing, `Button` | ⬜ |
 | 4 | `Constraints`, `Column`, `Row`, `Stack` | ⬜ |
 | 5 | `TextInput`, premier écran MVVM complet | ⬜ |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -6,8 +6,8 @@
 
 ## Phase 1 — Primitives ✅
 
-Branche : `feature/phase-1-core-primitives`  
-Tests : 46/46 ✅  
+Branche : `feature/phase-1-core-primitives` → mergée dans `develop`
+Tests : 46/46 ✅
 Dépendances externes : aucune
 
 ---
@@ -33,20 +33,20 @@ public abstract class Node
 
     // Cycle de vie
     public virtual void Init() { }
-    public virtual void Update(float delta) { }  // propagé aux enfants
+    public virtual void Update(float delta) { }    // propagé aux enfants
     public virtual void Layout(Size available) { } // propagé aux enfants
-    public virtual void Dispose() { }             // propagé aux enfants
+    public virtual void Paint(SKCanvas canvas) { } // propagé aux enfants avec Save/Translate/Restore
+    public virtual void Dispose() { }              // propagé aux enfants
 
     // Dirty flag
     public DirtyLevel Dirty { get; }
-    public bool IsDirty { get; }  // Dirty != None
-    public void MarkDirty(DirtyLevel level)   // escalade uniquement
-    public void MarkPaintDirty()              // → MarkDirty(Paint)
-    public void MarkLayoutDirty()             // → MarkDirty(Layout)
-    public void MarkLogicDirty()              // → MarkDirty(Logic)
-    internal void ClearDirty()               // → Dirty = None
+    public bool IsDirty { get; }         // Dirty != None
+    public void MarkDirty(DirtyLevel level)
+    public void MarkPaintDirty()         // → MarkDirty(Paint)
+    public void MarkLayoutDirty()        // → MarkDirty(Layout)
+    public void MarkLogicDirty()         // → MarkDirty(Logic)
+    internal void ClearDirty()          // → Dirty = None
 
-    // Rendu (Phase 2)
     public Rect ComputedBounds { get; protected set; }
 }
 ```
@@ -55,72 +55,82 @@ public abstract class Node
 - `AddChild` lance une exception si le Node a déjà un parent
 - `MarkDirty` n'escalade jamais vers le bas
 - Câbler `MarkXxxDirty()` sur les `ReactiveProperty<T>` dans `Init()`
+- Le parent gère la translation canvas avant d'appeler `Paint` sur les enfants
 
 ---
 
-### `ReactiveProperty<T>` — `HumbleEngine/Core/ReactiveProperty.cs`
+### Hiérarchie `ReactiveProperty<T>` — `HumbleEngine/Core/`
 
 ```csharp
-public class ReactiveProperty<T> : ISignal<T>
+// Interfaces
+public interface IReadOnlyReactiveProperty<out T> : ISignal<T>
+{
+    T Value { get; }
+    ISignal<T, T> Reaffected { get; }  // (oldValue, newValue) à chaque changement
+}
+
+public interface IReactiveProperty<T> : IReadOnlyReactiveProperty<T>
+{
+    new T Value { get; set; }
+}
+
+// Implémentations
+public class ReactiveProperty<T> : IReactiveProperty<T>
 {
     public ReactiveProperty(T initial)
-    public T Value { get; set; }         // notifie si valeur change
+    public T Value { get; set; }
+    public ISignal<T, T> Reaffected { get; }       // signal (oldValue, newValue)
     public void Connect(Action<T> listener)
     public void Disconnect(Action<T> listener)
-    public void BindFrom(ReactiveProperty<T> source)  // binding sens unique
+    public void BindFrom(ReactiveProperty<T> source) // binding sens unique
+    public static implicit operator T(ReactiveProperty<T> p) // lecture implicite
+}
+
+public class ReadOnlyReactiveProperty<T> : IReadOnlyReactiveProperty<T>
+{
+    public ReadOnlyReactiveProperty(ReactiveProperty<T> source)
+    public T Value { get; }
+    public ISignal<T, T> Reaffected { get; }
+    public void Connect(Action<T> listener)
+    public void Disconnect(Action<T> listener)
 }
 ```
 
 **Règles :**
-- Implémente `ISignal<T>` — utilisable partout où `ISignal<T>` est attendu
-- Égalité vérifiée avant notification — pas de boucle sur `BindFrom`
+- `IReadOnlyReactiveProperty<out T>` est covariant — `IReadOnlyReactiveProperty<Dog>` utilisable comme `IReadOnlyReactiveProperty<Animal>`
+- `Reaffected` fournit les deux valeurs : utile pour transitions, undo/redo
 - Délègue la notification à un `MutableSignal<T>` interne
 
 ---
 
-### `ISignal` / `ISignal<T>` — `HumbleEngine/Core/Signal.cs`
+### Hiérarchie `Signal` — `HumbleEngine/Core/Signal.cs`
 
 ```csharp
+// Interfaces (covariantes)
 public interface ISignal
-{
-    void Connect(Action listener);
-    void Disconnect(Action listener);
-}
+public interface ISignal<out T>
+public interface ISignal<out T1, out T2>
 
-public interface ISignal<T>
-{
-    void Connect(Action<T> listener);
-    void Disconnect(Action<T> listener);
-}
-```
-
----
-
-### `MutableSignal` / `Signal` — `HumbleEngine/Core/Signal.cs`
-
-```csharp
-// Côté émission — gardé privé dans le Node propriétaire
+// MutableSignal — côté émission, gardé privé
 public sealed class MutableSignal : ISignal
 {
-    public Signal Signal { get; }     // vue publique, créée dans le constructeur
+    public Signal Signal { get; }  // vue publique créée dans le constructeur
     public void Emit()
-    public void Connect(Action listener)
-    public void Disconnect(Action listener)
+    public void Connect(Action) / Disconnect(Action)
 }
+public sealed class MutableSignal<T> : ISignal<T>   { public void Emit(T value) ... }
+public sealed class MutableSignal<T1,T2> : ISignal<T1,T2> { public void Emit(T1, T2) ... }
 
-// Côté abonnement — exposé publiquement
-public sealed class Signal : ISignal
-{
-    internal Signal(MutableSignal owner)
-    public void Connect(Action listener)
-    public void Disconnect(Action listener)
-    // Emit() absent — cast Signal → MutableSignal impossible (types sans lien)
-}
-
-// Versions génériques identiques
-public sealed class MutableSignal<T> : ISignal<T> { ... }
-public sealed class Signal<T> : ISignal<T> { ... }
+// Signal — côté abonnement, exposé publiquement
+public sealed class Signal : ISignal           { internal Signal(MutableSignal) }
+public sealed class Signal<T> : ISignal<T>     { internal Signal(MutableSignal<T>) }
+public sealed class Signal<T1,T2> : ISignal<T1,T2> { internal Signal(MutableSignal<T1,T2>) }
 ```
+
+**Règles :**
+- `Signal` et `MutableSignal` sont sans lien d'héritage — cast impossible, encapsulation structurelle
+- `ISignal<out T>` est covariant grâce à la double contravariance de `Action<T>` en paramètre
+- Constructeurs `internal Signal(...)` — seul le moteur peut créer des `Signal`
 
 **Usage dans un Node :**
 ```csharp
@@ -131,33 +141,46 @@ public Signal Pressed => _pressed.Signal;
 
 ---
 
-### `ReactiveCollection<T>` — `HumbleEngine/Core/ReactiveCollection.cs`
+### Hiérarchie `ReactiveCollection<T>` — `HumbleEngine/Core/`
 
 ```csharp
-public class ReactiveCollection<T> : IReadOnlyList<T>
+// Interfaces
+public interface IReadOnlyReactiveCollection<out T> : IReadOnlyReactiveProperty<IReadOnlyList<T>>
 {
-    // Signaux (exposés en lecture seule via Signal)
-    public Signal<(int Index, T Item)> ItemAdded   { get; }
-    public Signal<(int Index, T Item)> ItemRemoved { get; }
-    public Signal                      Reset        { get; }
-    public Signal                      Changed      { get; }  // agrégat
+    ISignal<int, T> ItemAdded   { get; }
+    ISignal<int, T> ItemRemoved { get; }
+    ISignal          Cleared     { get; }
+    ISignal          Changed     { get; }
+}
 
-    // Mutation
-    public void Add(T item)
-    public void Insert(int index, T item)
-    public bool Remove(T item)
-    public void RemoveAt(int index)
-    public void Clear()
+public interface IReactiveCollection<T>
+    : IReadOnlyReactiveCollection<T>, IReactiveProperty<IReadOnlyList<T>>, IList<T>
 
-    // IReadOnlyList<T>
-    public T this[int index] { get; }
-    public int Count { get; }
+// Implémentations
+public class ReactiveCollection<T> : IReactiveCollection<T>
+{
+    // Signaux
+    ISignal<int, T> ItemAdded   // index + item ajouté
+    ISignal<int, T> ItemRemoved // index + item supprimé
+    ISignal          Cleared     // liste vidée
+    ISignal          Changed     // agrégat : fire après toute mutation
+
+    // IList<T> — toutes les méthodes émettent les signaux appropriés
+    // Indexeur setter : RemoveAt + Insert (émet ItemRemoved + ItemAdded)
+    // Value : réaffectation émet ItemRemoved pour chaque ancien item, ItemAdded pour chaque nouveau
+}
+
+public class ReadOnlyReactiveCollection<T> : IReadOnlyReactiveCollection<T>
+{
+    public ReadOnlyReactiveCollection(IReactiveCollection<T> source)
+    // Expose Value, Reaffected, ItemAdded, ItemRemoved, Cleared, Changed en lecture seule
 }
 ```
 
 **Règles :**
-- `Changed` est levé après chaque mutation (Add, Insert, RemoveAt, Clear)
-- Les `MutableSignal` sont privés — les consommateurs reçoivent des `Signal`
+- `Changed` est dérivé — câblé sur `ItemAdded`/`ItemRemoved`/`Cleared` dans le constructeur, jamais émis manuellement
+- `IReadOnlyReactiveCollection<out T>` est covariant
+- Lors d'une réaffectation (`Value = newList`), `Reaffected` fire les items individuels de l'ancien et du nouveau
 
 ---
 
@@ -173,22 +196,10 @@ public readonly record struct Rect(float X, float Y, float Width, float Height)
 
 ---
 
----
-
 ## Phase 2 — Premier rendu ✅
 
-Branche : `feature/phase-2-rendering`  
-Tests : 46/46 ✅ (Phase 1 inchangés — Phase 2 nécessite GPU)
-
----
-
-### `Node` — ajout Phase 2
-
-```csharp
-// Nouveau dans Phase 2
-public virtual void Paint(SKCanvas canvas)
-// Propage aux enfants avec Save/Translate/Restore par enfant
-```
+Branche : `feature/phase-2-rendering`
+Tests : 46/46 ✅ (Phase 2 nécessite GPU — pas de tests unitaires)
 
 ---
 
@@ -199,17 +210,18 @@ public sealed class Application : IDisposable
 {
     public Node? Root { get; set; }
     public Application(string title = "HumbleEngine", int width = 800, int height = 600)
-    public void Run()
+    public void Run()    // bloque jusqu'à fermeture
     public void Dispose()
 }
 ```
 
 **Boucle interne (par frame) :**
-1. `Root.Layout(windowSize)` — recalcule le layout
-2. `canvas.Clear(White)` + `Root.Paint(canvas)` — redessine
+1. `Root.Layout(windowSize)`
+2. `canvas.Clear(White)` + `Root.Paint(canvas)`
 3. `canvas.Flush()` + `Root.ClearDirty()`
 
-**Stack technique :** Silk.NET (fenêtre + contexte OpenGL) + SkiaSharp (rendu GPU via GRContext).
+**Stack :** Silk.NET GLFW (fenêtre + contexte OpenGL) + SkiaSharp GRContext (rendu GPU).
+`GRGlInterface.Create()` détecte le contexte GL courant. `FramebufferSize` (pixels physiques) pour HiDPI.
 
 ---
 
@@ -221,16 +233,13 @@ public class Label : Node
     public ReactiveProperty<string>  Text     = new("");
     public ReactiveProperty<SKColor> Color    = new(SKColors.Black);
     public ReactiveProperty<float>   FontSize = new(16f);
-
-    // Layout : mesure le texte → ComputedBounds.Width/Height
-    // Paint  : DrawText à l'origine (parent gère la translation)
 }
 ```
 
-**Règles :**
 - `Text` / `Color` → `MarkPaintDirty()`
 - `FontSize` → `MarkLayoutDirty()`
-- Le parent est responsable de placer `ComputedBounds.X/Y`
+- `Layout` : `SKFont.MeasureText` → `ComputedBounds.Width/Height`
+- `Paint` : `canvas.DrawText` à l'origine, y = `-font.Metrics.Ascent`
 
 ---
 


### PR DESCRIPTION
## Summary

**Phase 2 — Rendu**
- `Node.Paint(SKCanvas)` — propagation aux enfants avec Save/Translate/Restore
- `Application` — Silk.NET + SkiaSharp GRContext, boucle Update→Layout→Paint
- `Label` — Layout (mesure texte SKFont) + Paint (DrawText)
- `HumbleEngine.Sample` — démo fonctionnelle confirmée

**Extensions Phase 1**
- `IReactiveProperty<T>` / `IReadOnlyReactiveProperty<out T>` / `ReadOnlyReactiveProperty<T>`
- `ReactiveProperty<T>.Reaffected` — signal `(oldValue, newValue)`
- `Signal<T1,T2>` / `MutableSignal<T1,T2>` / `ISignal<out T1, out T2>`
- `IReactiveCollection<T>` / `IReadOnlyReactiveCollection<out T>` / `ReadOnlyReactiveCollection<T>`
- `ReactiveCollection<T>` refactorisé — `IList<T>`, `Changed` dérivé, `Reaffected` diff automatique
- Implicit read operator sur `ReactiveProperty<T>`

## Test plan

- [x] `dotnet test` — 46/46 ✅
- [x] `dotnet run --project HumbleEngine.Sample` — fenêtre avec Label ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)