### PR TITLE
Implement RenderNodeTree — flat array with index-based typed data

### DIFF
--- a/HumbleEngine/Application.cs
+++ b/HumbleEngine/Application.cs
@@ -7,8 +7,9 @@ namespace HumbleEngine;
 public sealed class Application : IDisposable
 {
     private readonly IWindow _window;
-    private GRContext?  _grContext;  // contexte GPU SkiaSharp — wraps le contexte OpenGL
-    private SKSurface?  _surface;   // surface de rendu liée au framebuffer de la fenêtre
+    private GRContext?  _grContext;   // contexte GPU SkiaSharp — wraps le contexte OpenGL
+    private SKSurface?  _surface;    // surface de rendu liée au framebuffer de la fenêtre
+    private readonly RenderNodeTree _renderTree = new();
 
     public Node? Root { get; set; }
 
@@ -95,9 +96,12 @@ public sealed class Application : IDisposable
         // Layout : calcule les positions et tailles de tous les Nodes
         Root.Layout(new Size(_window.Size.X, _window.Size.Y));
 
-        // Efface le framebuffer puis demande à chaque Node de se dessiner
+        // Construit le Render Tree plat depuis le Node Tree
+        _renderTree.Rebuild(Root);
+
+        // Efface le framebuffer puis peint via le Render Tree
         canvas.Clear(SKColors.White);
-        Root.Paint(canvas);
+        _renderTree.Paint(canvas);
 
         // Flush soumet les commandes SkiaSharp au driver OpenGL
         canvas.Flush();

--- a/HumbleEngine/Core/IRenderNode.cs
+++ b/HumbleEngine/Core/IRenderNode.cs
@@ -1,0 +1,5 @@
+namespace HumbleEngine;
+
+// Interface marqueur — conservée pour extensibilité future.
+// La navigation dans l'arbre passe par RenderNodeTree, pas par cette interface.
+public interface IRenderNode { }

--- a/HumbleEngine/Core/Node.cs
+++ b/HumbleEngine/Core/Node.cs
@@ -72,4 +72,8 @@ public abstract class Node
     }
 
     public Rect ComputedBounds { get; protected set; }
+
+    // Retourne la description visuelle de ce nœud pour le RenderNodeTree.
+    // Les nœuds purement logiques (conteneurs sans visuel propre) retournent None.
+    public virtual RenderNodeData CreateRenderNode() => RenderNodeData.None;
 }

--- a/HumbleEngine/Core/RenderNode.cs
+++ b/HumbleEngine/Core/RenderNode.cs
@@ -1,0 +1,12 @@
+namespace HumbleEngine;
+
+// Nœud de rendu stocké dans le tableau plat du RenderNodeTree.
+// Taille fixe quelle que soit la nature du nœud.
+// Les données spécifiques au type sont dans les tableaux typés du RenderNodeTree,
+// accessibles via Index.
+public readonly struct RenderNode
+{
+    public RenderNodeKind Kind   { get; init; }  // quel type de nœud
+    public int            Index  { get; init; }  // index dans le tableau typé correspondant
+    public Rect           Bounds { get; init; }  // bounds absolues (calculées pendant Rebuild)
+}

--- a/HumbleEngine/Core/RenderNodeData.cs
+++ b/HumbleEngine/Core/RenderNodeData.cs
@@ -1,0 +1,13 @@
+namespace HumbleEngine;
+
+// Valeur transitoire retournée par Node.CreateRenderNode().
+// N'est jamais stockée dans le RenderNodeTree — sert uniquement
+// à transporter les données du Node vers le Build.
+public readonly struct RenderNodeData
+{
+    public static readonly RenderNodeData None = default;
+
+    public RenderNodeKind Kind { get; init; }
+    public TextData       Text { get; init; }
+    // Ajouter les autres types ici au fur et à mesure (BoxData, ImageData, etc.)
+}

--- a/HumbleEngine/Core/RenderNodeKind.cs
+++ b/HumbleEngine/Core/RenderNodeKind.cs
@@ -1,0 +1,8 @@
+namespace HumbleEngine;
+
+public enum RenderNodeKind
+{
+    None,
+    Text,
+    Box,
+}

--- a/HumbleEngine/Core/RenderNodeTree.cs
+++ b/HumbleEngine/Core/RenderNodeTree.cs
@@ -1,0 +1,103 @@
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public sealed class RenderNodeTree
+{
+    private readonly List<RenderNode> _nodes        = new();
+    private readonly List<int>        _subtreeSizes = new();
+
+    // Tableaux typés — un par RenderNodeKind
+    private readonly List<TextData> _textData = new();
+
+    // --- Construction ---
+
+    public void Rebuild(Node root)
+    {
+        _nodes.Clear();
+        _subtreeSizes.Clear();
+        _textData.Clear();
+
+        Build(root, offsetX: 0, offsetY: 0);
+    }
+
+    private int Build(Node node, float offsetX, float offsetY)
+    {
+        // Réserve une place pour ce nœud
+        int myIndex = _nodes.Count;
+        _nodes.Add(default);
+        _subtreeSizes.Add(0);
+
+        // Bounds absolues = position relative au parent + offset accumulé
+        float absX = offsetX + node.ComputedBounds.X;
+        float absY = offsetY + node.ComputedBounds.Y;
+        var   abs  = new Rect(absX, absY, node.ComputedBounds.Width, node.ComputedBounds.Height);
+
+        // Récupère la description visuelle du nœud et stocke la donnée typée
+        var data       = node.CreateRenderNode();
+        int dataIndex  = StoreData(data);
+
+        // Construit récursivement les enfants (ils s'ajoutent après ce nœud)
+        int subtreeSize = 1;
+        foreach (var child in node.Children)
+            subtreeSize += Build(child, absX, absY);
+
+        // Remplit la place réservée
+        _nodes[myIndex]        = new RenderNode { Kind = data.Kind, Index = dataIndex, Bounds = abs };
+        _subtreeSizes[myIndex] = subtreeSize;
+
+        return subtreeSize;
+    }
+
+    private int StoreData(RenderNodeData data)
+    {
+        switch (data.Kind)
+        {
+            case RenderNodeKind.Text:
+                _textData.Add(data.Text);
+                return _textData.Count - 1;
+            default:
+                return -1;
+        }
+    }
+
+    // --- Rendu ---
+
+    public void Paint(SKCanvas canvas)
+    {
+        for (int i = 0; i < _nodes.Count; i++)
+        {
+            var node = _nodes[i];
+            switch (node.Kind)
+            {
+                case RenderNodeKind.Text:
+                    PaintText(canvas, node.Bounds, _textData[node.Index]);
+                    break;
+            }
+        }
+    }
+
+    private static void PaintText(SKCanvas canvas, Rect bounds, TextData data)
+    {
+        if (string.IsNullOrEmpty(data.Content)) return;
+
+        using var font  = new SKFont(SKTypeface.Default, data.FontSize);
+        using var paint = new SKPaint { Color = data.Color, IsAntialias = true };
+
+        canvas.DrawText(data.Content, bounds.X, bounds.Y - font.Metrics.Ascent, font, paint);
+    }
+
+    // --- Navigation (utilitaire) ---
+
+    // Itère les indices directs des enfants d'un nœud.
+    public IEnumerable<int> ChildIndices(int parentIndex)
+    {
+        int end        = parentIndex + _subtreeSizes[parentIndex];
+        int childIndex = parentIndex + 1;
+        while (childIndex < end)
+        {
+            yield return childIndex;
+            childIndex += _subtreeSizes[childIndex];
+        }
+    }
+}

--- a/HumbleEngine/Core/TextData.cs
+++ b/HumbleEngine/Core/TextData.cs
@@ -1,0 +1,10 @@
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public readonly struct TextData
+{
+    public string  Content  { get; init; }
+    public SKColor Color    { get; init; }
+    public float   FontSize { get; init; }
+}

--- a/HumbleEngine/Nodes/Label.cs
+++ b/HumbleEngine/Nodes/Label.cs
@@ -25,14 +25,14 @@ public class Label : Node
         ComputedBounds = new Rect(ComputedBounds.X, ComputedBounds.Y, width, height);
     }
 
-    public override void Paint(SKCanvas canvas)
+    public override RenderNodeData CreateRenderNode() => new()
     {
-        if (string.IsNullOrEmpty(Text.Value)) return;
-
-        using var font  = new SKFont(SKTypeface.Default, FontSize.Value);
-        using var paint = new SKPaint { Color = Color.Value, IsAntialias = true };
-
-        // y = -Ascent place le haut du texte à y=0 (origine du ComputedBounds)
-        canvas.DrawText(Text.Value, 0, -font.Metrics.Ascent, font, paint);
-    }
+        Kind = RenderNodeKind.Text,
+        Text = new TextData
+        {
+            Content  = Text.Value,
+            Color    = Color.Value,
+            FontSize = FontSize.Value
+        }
+    };
 }


### PR DESCRIPTION
## Summary

- `RenderNode` : struct fixe 24 bytes (Kind, Index, Bounds absolues)
- `RenderNodeKind` : enum des types visuels
- `RenderNodeData` : tagged union transitoire retourné par `Node.CreateRenderNode()`
- `TextData` : données texte stockées dans `_textData[]`
- `RenderNodeTree` : tableau plat + subtreeSizes + tableaux typés par Kind
  - `Rebuild(root)` — DFS avec accumulation d'offsets, remplit les tableaux
  - `Paint(canvas)` — scan linéaire, dispatch sur Kind
  - `ChildIndices(i)` — navigation par arithmétique de subtreeSize
- `Node.CreateRenderNode()` — virtuel, retourne `RenderNodeData.None` par défaut
- `Label` — implémente `CreateRenderNode()` au lieu de `Paint()`
- `Application` — tient un `RenderNodeTree`, `Rebuild` + `Paint` par frame

## Test plan

- [x] `dotnet test` — 46/46 ✅
- [x] `dotnet build` — 0 erreurs ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)