### PR TITLE
Phase 3 — Button node + Render() refactor

### DIFF
--- a/HumbleEngine/Nodes/Button.cs
+++ b/HumbleEngine/Nodes/Button.cs
@@ -1,0 +1,58 @@
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public class Button : Node
+{
+    private const float PaddingX = 16f;
+    private const float PaddingY = 8f;
+
+    public ReactiveProperty<string>  Text            = new("");
+    public ReactiveProperty<SKColor> BackgroundColor = new(new SKColor(220, 220, 220));
+    public ReactiveProperty<SKColor> HoverColor      = new(new SKColor(190, 210, 240));
+    public ReactiveProperty<float>   FontSize        = new(16f);
+
+    private bool _isHovered;
+
+    private readonly MutableSignal _pressed = new();
+    public Signal Pressed => _pressed.Signal;
+
+    public override HitTestFilter MouseFilter => HitTestFilter.Stop;
+
+    public override void Init()
+    {
+        base.Init();
+        Text.Connect(_  => MarkLayoutDirty());
+        FontSize.Connect(_ => MarkLayoutDirty());
+        BackgroundColor.Connect(_ => MarkPaintDirty());
+        HoverColor.Connect(_ => MarkPaintDirty());
+    }
+
+    public override void OnMouseEnter() { _isHovered = true;  MarkPaintDirty(); }
+    public override void OnMouseLeave() { _isHovered = false; MarkPaintDirty(); }
+    public override void OnClick()      { _pressed.Emit(); }
+
+    public override void Layout(Size available)
+    {
+        using var font  = new SKFont(SKTypeface.Default, FontSize.Value);
+        var textWidth   = font.MeasureText(Text.Value);
+        var textHeight  = font.Metrics.Descent - font.Metrics.Ascent;
+
+        ComputedBounds = ComputedBounds with
+        {
+            Width  = textWidth  + PaddingX * 2,
+            Height = textHeight + PaddingY * 2,
+        };
+    }
+
+    public override RenderDescription Render()
+    {
+        var bg = _isHovered ? HoverColor.Value : BackgroundColor.Value;
+
+        RenderDescription text = new Text(Text.Value, SKColors.Black, FontSize.Value);
+        text = text with { Bounds = new Rect(PaddingX, PaddingY, 0, 0) };
+
+        RenderDescription box = new Box(bg) { text };
+        return box with { Bounds = ComputedBounds };
+    }
+}

--- a/HumbleEngine/Nodes/Button.cs
+++ b/HumbleEngine/Nodes/Button.cs
@@ -45,14 +45,12 @@ public class Button : Node
         };
     }
 
-    public override RenderDescription Render()
+    protected override RenderDescription RenderContent()
     {
         var bg = _isHovered ? HoverColor.Value : BackgroundColor.Value;
-
-        RenderDescription text = new Text(Text.Value, SKColors.Black, FontSize.Value);
-        text = text with { Bounds = new Rect(PaddingX, PaddingY, 0, 0) };
-
-        RenderDescription box = new Box(bg) { text };
-        return box with { Bounds = ComputedBounds };
+        return new Box(bg)
+        {
+            new Text(Text.Value, SKColors.Black, FontSize.Value).At(PaddingX, PaddingY)
+        };
     }
 }

--- a/HumbleEngine/Nodes/Label.cs
+++ b/HumbleEngine/Nodes/Label.cs
@@ -25,9 +25,6 @@ public class Label : Node
         ComputedBounds = new Rect(ComputedBounds.X, ComputedBounds.Y, width, height);
     }
 
-    public override RenderDescription Render()
-    {
-        RenderDescription desc = new Text(Text.Value, Color.Value, FontSize.Value);
-        return desc with { Bounds = ComputedBounds };
-    }
+    protected override RenderDescription RenderContent()
+        => new Text(Text.Value, Color.Value, FontSize.Value);
 }

--- a/HumbleEngine/Rendering/Builders/Box/Box.cs
+++ b/HumbleEngine/Rendering/Builders/Box/Box.cs
@@ -1,8 +1,9 @@
+using System.Collections;
 using SkiaSharp;
 
 namespace HumbleEngine;
 
-public struct Box
+public struct Box : IEnumerable<RenderDescription>
 {
     private readonly SKColor _color;
     private readonly float   _cornerRadius;
@@ -26,4 +27,9 @@ public struct Box
         Box      = new BoxData { BackgroundColor = b._color, CornerRadius = b._cornerRadius },
         Children = b._children?.ToArray() ?? Array.Empty<RenderDescription>()
     };
+
+    public IEnumerator<RenderDescription> GetEnumerator() =>
+        (_children ?? Enumerable.Empty<RenderDescription>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/HumbleEngine/Rendering/Builders/Column/Column.cs
+++ b/HumbleEngine/Rendering/Builders/Column/Column.cs
@@ -1,9 +1,8 @@
+using System.Collections;
+
 namespace HumbleEngine;
 
-// Builder pour un conteneur vertical.
-// Supporte la syntaxe collection initializer : new Column { child1, child2 }
-// Les éléments sont automatiquement convertis en RenderDescription via implicit operators.
-public struct Column
+public struct Column : IEnumerable<RenderDescription>
 {
     private List<RenderDescription>? _children;
 
@@ -18,4 +17,9 @@ public struct Column
         Kind     = RenderNodeKind.Column,
         Children = col._children?.ToArray() ?? Array.Empty<RenderDescription>()
     };
+
+    public IEnumerator<RenderDescription> GetEnumerator() =>
+        (_children ?? Enumerable.Empty<RenderDescription>()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/HumbleEngine/Rendering/Builders/Text/Text.cs
+++ b/HumbleEngine/Rendering/Builders/Text/Text.cs
@@ -22,4 +22,8 @@ public readonly struct Text
         Kind = RenderNodeKind.Text,
         Text = new TextData { Content = t._content, Color = t._color, FontSize = t._fontSize }
     };
+
+    public RenderDescription At(Rect bounds) => ((RenderDescription)this) with { Bounds = bounds };
+
+    public RenderDescription At(float x, float y) => At(new Rect(x, y, 0, 0));
 }

--- a/HumbleEngine/Scene/Node.cs
+++ b/HumbleEngine/Scene/Node.cs
@@ -83,5 +83,7 @@ public abstract class Node
 
     // Retourne la description visuelle de ce nœud pour le RenderNodeTree.
     // Les nœuds purement logiques (conteneurs sans visuel propre) retournent None.
-    public virtual RenderDescription Render() => RenderDescription.None;
+    public RenderDescription Render() => RenderContent() with { Bounds = ComputedBounds };
+
+    protected virtual RenderDescription RenderContent() => RenderDescription.None;
 }


### PR DESCRIPTION
## Summary
- Add Button node: Text/BackgroundColor/HoverColor/FontSize props, Pressed signal, hover state, MouseFilter=Stop
- Fix Box and Column builders: implement IEnumerable<RenderDescription> for collection initializer syntax
- Refactor Render() — Template Method pattern: Render() non-virtual injects ComputedBounds, subclasses override RenderContent()
- Add At(Rect) / At(float x, float y) on Text builder for declarative child positioning

## Test plan
- [ ] Button renders with background color
- [ ] Hover color changes on mouse enter/leave
- [ ] Pressed signal fires on confirmed click (Down+Up on same node)
- [ ] Label and Button RenderContent() have no manual bounds injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)