### PR TITLE
Restructure docs — index + per-phase files

### DIFF
--- a/docs/Indexes/project-status.md
+++ b/docs/Indexes/project-status.md
@@ -1,0 +1,66 @@
+# HumbleEngine — Index projet
+
+> Fichier auto-maintenu par Claude. Ne pas éditer manuellement.
+> Chargé en début de chaque session.
+
+---
+
+## Structure du projet
+
+```
+HumbleEngine/
+├── Application.cs
+├── Reactivity/          Signal, ReactiveProperty, ReactiveCollection
+├── Scene/               Node, DirtyLevel, Geometry, HitTestFilter, HitTest
+├── Rendering/           RenderEntry, RenderTree, RenderDescription, RenderEntryKind
+│   │                    BoxConstraints, LayoutData, LinearLayoutData
+│   │                    IRenderElement, ICompositeRenderElement, RenderElementExtensions
+│   └── RenderElements/
+│       ├── Span/        Span, SpanData
+│       ├── Box/         Box, BoxData
+│       ├── VLayout/     VLayout (vertical, XXXLayout = pas de visuel)
+│       └── HLayout/     HLayout (horizontal)
+└── Nodes/
+    ├── Label.cs
+    ├── Button.cs
+    └── Layout/          Column, Row
+
+HumbleEngine.Tests/
+├── Core/                NodeTests, SignalTests, ReactivePropertyTests, ReactiveCollectionTests
+├── Rendering/           BoxConstraintsTests, LayoutTests
+└── Input/               HitTestTests
+```
+
+Tous les types dans `namespace HumbleEngine;`
+
+---
+
+## Phases
+
+| Phase | Contenu | Statut | Détails |
+|-------|---------|--------|---------|
+| 1 + 2 | Primitives + Premier rendu | ✅ | `docs/Status/phase-1-2.md` |
+| 3 | Input system, HitTest, Button | ✅ | `docs/Status/phase-3.md` |
+| 4 | Layout pivot, Column/Row, nomenclature | ✅ | `docs/Status/phase-4.md` |
+| 5 | TextInput, premier écran MVVM | ⬜ | |
+
+Tests : **72/72** ✅
+
+---
+
+## Règles invariantes
+
+**Code**
+- `namespace HumbleEngine;` — partout, pas de sous-namespaces
+- Framework de tests : **NUnit** (pas xUnit)
+- Layout dans `RenderTree`, **jamais** dans `Node`
+- `Node.Render()` non-virtual → `RenderContent()` surchargé (Template Method)
+- `[CollectionBuilder]` sur tout `ICompositeRenderElement` — syntaxe `[..spread]`
+- Convention nommage : `XXXLayout` = pas de visuel propre ; sans suffix = visuel
+- `ComputedBounds` — écrit par `RenderTree` après layout pass, lu par HitTest
+
+**Process**
+- Une étape à la fois, récap + quiz après chaque étape
+- Commit + push après chaque étape validée
+- Merger via PR sur `develop`, nouvelle branche pour chaque phase
+- Mettre à jour `docs/Indexes/project-status.md` après chaque phase

--- a/docs/Status/phase-1-2.md
+++ b/docs/Status/phase-1-2.md
@@ -1,0 +1,172 @@
+# Phase 1 — Primitives ✅ + Phase 2 — Premier rendu ✅
+
+Tests Phase 1 : 46/46 ✅ — Phase 2 requiert GPU, pas de tests unitaires
+
+---
+
+## `DirtyLevel` — `Scene/DirtyLevel.cs`
+
+```csharp
+public enum DirtyLevel { None, Paint, Layout, Logic }
+```
+
+---
+
+## `Node` — `Scene/Node.cs`
+
+```csharp
+public abstract class Node
+{
+    public Node? Parent { get; }
+    public IReadOnlyList<Node> Children { get; }
+    public void AddChild(Node child)     // appelle child.Init()
+    public void RemoveChild(Node child)  // appelle child.Dispose()
+
+    public virtual void Init() { }
+    public virtual void Update(float delta) { }  // propagé aux enfants
+    public virtual void Dispose() { }
+
+    public DirtyLevel Dirty { get; }
+    public bool IsDirty { get; }
+    public void MarkDirty(DirtyLevel level)
+    public void MarkPaintDirty()
+    public void MarkLayoutDirty()
+    public void MarkLogicDirty()
+    internal void ClearDirty()
+
+    // Input
+    public virtual HitTestFilter MouseFilter => HitTestFilter.Ignore;
+    public virtual void OnMouseEnter() { }
+    public virtual void OnMouseLeave() { }
+    public virtual void OnMouseDown()  { }
+    public virtual void OnMouseUp()    { }
+    public virtual void OnClick()      { }
+
+    // Rendu — Template Method
+    public Rect ComputedBounds { get; internal set; }  // écrit par RenderTree
+    public RenderDescription Render() => RenderContent() with { Owner = this };
+    protected virtual RenderDescription RenderContent() => RenderDescription.None;
+}
+```
+
+**Règles :**
+- `AddChild` lance une exception si le Node a déjà un parent
+- Câbler `MarkXxxDirty()` sur les `ReactiveProperty<T>` dans `Init()`
+- Layout et Paint délégués au `RenderTree` — ne pas les implémenter sur Node
+
+---
+
+## `ReactiveProperty<T>` — `Reactivity/`
+
+```csharp
+public class ReactiveProperty<T> : IReactiveProperty<T>
+{
+    public ReactiveProperty(T initial)
+    public T Value { get; set; }
+    public ISignal<T, T> Reaffected { get; }  // (oldValue, newValue)
+    public void Connect(Action<T> listener)
+    public void Disconnect(Action<T> listener)
+    public void BindFrom(ReactiveProperty<T> source)
+    public static implicit operator T(ReactiveProperty<T> p)
+}
+```
+
+---
+
+## `Signal` — `Reactivity/Signal.cs`
+
+```csharp
+public sealed class MutableSignal : ISignal { public void Emit(); }
+public sealed class Signal : ISignal        { internal Signal(MutableSignal owner); }
+// Idem pour MutableSignal<T>/Signal<T> et MutableSignal<T1,T2>/Signal<T1,T2>
+```
+
+Usage :
+```csharp
+private readonly MutableSignal _pressed = new();
+public Signal Pressed => _pressed.Signal;
+```
+
+---
+
+## `ReactiveCollection<T>` — `Reactivity/`
+
+```csharp
+public class ReactiveCollection<T> : IReactiveCollection<T>
+// ISignal<int,T> ItemAdded, ItemRemoved — ISignal Cleared, Changed
+```
+
+---
+
+## `Size` / `Rect` — `Scene/Geometry.cs`
+
+```csharp
+public readonly record struct Size(float Width, float Height);
+public readonly record struct Rect(float X, float Y, float Width, float Height)
+{
+    public bool Contains(float x, float y)
+}
+```
+
+---
+
+## `Application` — `Application.cs`
+
+**Boucle par frame :**
+1. `_renderTree.Rebuild(Root)` — Node.Render() → Flatten → tableaux plats
+2. `_renderTree.Layout(BoxConstraints.Loose(windowSize))` — calcule les bounds
+3. `canvas.Clear(White)` + `_renderTree.Paint(canvas)`
+4. `canvas.Flush()` + `Root.ClearDirty()`
+
+**Stack :** Silk.NET GLFW + SkiaSharp GRContext. `FramebufferSize` pour HiDPI.
+
+---
+
+## Render Tree — `Rendering/`
+
+```csharp
+public readonly struct RenderEntry
+{
+    public RenderEntryKind Kind   { get; init; }
+    public int             Index  { get; init; }
+    public Rect            Bounds { get; init; }
+}
+
+public enum RenderEntryKind { None, Span, Box, VLayout, HLayout }
+
+public readonly struct RenderDescription
+{
+    public static implicit operator RenderDescription(string content) => new Span(content);
+    public RenderEntryKind       Kind         { get; internal init; }
+    public Rect                  Bounds       { get; internal init; }
+    public RenderDescription[]?  Children     { get; internal init; }
+    public SpanData              Span         { get; internal init; }
+    public BoxData               Box          { get; internal init; }
+    public LinearLayoutData      LinearLayout { get; internal init; }
+    public LayoutData            Layout       { get; internal init; }
+    public Node?                 Owner        { get; internal init; }
+}
+
+public sealed class RenderTree
+{
+    public void Rebuild(Node root)
+    public void Layout(BoxConstraints constraints)
+    public void Paint(SKCanvas canvas)
+    public IEnumerable<int> ChildIndices(int parentIndex)
+}
+```
+
+---
+
+## `Label` — `Nodes/Label.cs`
+
+```csharp
+public class Label : Node
+{
+    public ReactiveProperty<string>  Text     = new("");
+    public ReactiveProperty<SKColor> Color    = new(SKColors.Black);
+    public ReactiveProperty<float>   FontSize = new(16f);
+    // Text/FontSize → MarkLayoutDirty(), Color → MarkPaintDirty()
+    // RenderContent : new Span(Text.Value).Color(Color.Value).FontSize(FontSize.Value)
+}
+```

--- a/docs/Status/phase-3.md
+++ b/docs/Status/phase-3.md
@@ -1,0 +1,60 @@
+# Phase 3 — Input system, HitTest, Button ✅
+
+---
+
+## `HitTestFilter` — `Scene/HitTestFilter.cs`
+
+```csharp
+public enum HitTestFilter { Ignore, Pass, Stop, Disabled }
+//  Ignore   = hover uniquement, pas de click (défaut Node)
+//  Pass     = hover + click, propagé vers les ancêtres
+//  Stop     = hover + click, stoppé
+//  Disabled = aucun événement (ni hover ni click)
+```
+
+---
+
+## `HitTest` — `Scene/HitTest.cs`
+
+```csharp
+public static class HitTest
+{
+    public static Node? Find(Node root, float x, float y)          // depth-first, filtre ignoré
+    public static void DispatchClick(Node? node)                    // remonte avec filtre
+    public static List<Node> GetHoveredPath(Node? node)            // exclut Disabled
+    public static Node? FirstInteractive(List<Node> path)          // premier Pass ou Stop
+}
+```
+
+**Règles :**
+- Clic confirmé : `_pressedNode` (FirstInteractive au MouseDown) encore dans le chemin au MouseUp
+- `MouseEnter`/`Leave` : diff ancien/nouveau chemin, toujours propagés (pas filtrés)
+- `MouseFilter` n'affecte que les clics, pas le hover
+
+---
+
+## Input dans `Application`
+
+```
+mouse.MouseMove  → HitTest.Find → diff _hoveredPath → OnMouseLeave/OnMouseEnter
+mouse.MouseDown  → _pressedNode = FirstInteractive(_hoveredPath) + OnMouseDown
+mouse.MouseUp    → OnMouseUp + si _pressedNode ∈ _hoveredPath → DispatchClick
+```
+
+---
+
+## `Button` — `Nodes/Button.cs`
+
+```csharp
+public class Button : Node
+{
+    public ReactiveProperty<string>  Text            = new("");
+    public ReactiveProperty<SKColor> BackgroundColor = new(SKColor(220,220,220));
+    public ReactiveProperty<SKColor> HoverColor      = new(SKColor(190,210,240));
+    public ReactiveProperty<float>   FontSize        = new(16f);
+    public Signal Pressed { get; }
+    public override HitTestFilter MouseFilter => HitTestFilter.Stop;
+    // _isHovered toggle → MarkPaintDirty
+    // RenderContent : new Box { new Span(...) }.Color(bg).Padding(16f, 8f)
+}
+```

--- a/docs/Status/phase-4.md
+++ b/docs/Status/phase-4.md
@@ -1,0 +1,94 @@
+# Phase 4 — Layout pivot + Column/Row ✅
+
+Tests : 72/72 ✅
+
+---
+
+## Layout pivot — RenderTree owns layout
+
+**Avant :** `Node.Layout(Size available)` calculait `ComputedBounds`.
+**Après :** `RenderTree.Layout(BoxConstraints)` calcule tout, écrit `Node.ComputedBounds`.
+
+**Algorithme :**
+- Descente : `BoxConstraints` parent → enfant
+- Remontée : tailles enfant → parent (hug content ou taille explicite)
+- `Span` → taille intrinsèque via `SKFont.MeasureText`
+- `Box` → padding + max enfant (layering)
+- `VLayout` → padding + somme enfants + spacing (vertical)
+- `HLayout` → padding + somme enfants + spacing (horizontal)
+
+---
+
+## Nouveaux types de layout
+
+```csharp
+public readonly struct BoxConstraints
+{
+    public static BoxConstraints Loose(Size available)  // min=0, max=available
+    public static BoxConstraints Tight(Size size)        // min=max=size
+    public static BoxConstraints Unconstrained           // max=∞
+    public Size Constrain(float width, float height)     // clamp
+}
+
+public readonly struct LayoutData
+{
+    public float? Width, Height;  // null = hug content
+    public float  PaddingX, PaddingY;
+}
+
+public readonly struct LinearLayoutData { public float Spacing; }
+// Partagé entre VLayout et HLayout
+```
+
+---
+
+## Render elements (IRenderElement / ICompositeRenderElement)
+
+**Convention :** `XXXLayout` = pas de visuel propre ; sans suffix = visuel.
+
+```csharp
+// VLayout / HLayout — layout pur, [CollectionBuilder] supporté
+VLayout layout = [child1, ..spread, child2];
+return layout.Spacing(8f).Padding(16f);
+
+// Box — fond + enfants
+Box box = [child];
+return box.Color(SKColors.Red).CornerRadius(4f);
+
+// Span — texte stylé
+new Span("text").Color(SKColors.Gray).FontSize(12f).Width(200f)
+```
+
+**`RenderElementExtensions`** — sur tout `T : struct, IRenderElement` :
+`Width`, `Height`, `Padding` + `Create<T>` (helper pour `[CollectionBuilder]`)
+
+---
+
+## Column / Row Nodes — `Nodes/Layout/`
+
+```csharp
+public class Column : Node
+{
+    public ReactiveProperty<float> Spacing = new(0f);
+    protected override RenderDescription RenderContent()
+    {
+        VLayout layout = [..Children.Select(c => c.Render())];
+        return layout.Spacing(Spacing.Value);
+    }
+}
+// Row : identique avec HLayout
+```
+
+---
+
+## Nomenclature Rendering (refactor)
+
+| Ancien | Actuel |
+|--------|--------|
+| `RenderNodeTree` | `RenderTree` |
+| `RenderNode` struct | `RenderEntry` |
+| `RenderNodeKind` | `RenderEntryKind` |
+| `IRenderNode` | `IRenderElement` |
+| `ICompositeRenderNode` | `ICompositeRenderElement` |
+| `RenderNodeExtensions` | `RenderElementExtensions` |
+| `Builders/` | `RenderElements/` |


### PR DESCRIPTION
Replace monolithic implementation-status.md with compact index + per-phase detail files to reduce token cost per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)