### PR TITLE
Phase 5 — TextInput + premier écran MVVM

### DIFF
--- a/HumbleEngine.Tests/Core/TextInputTests.cs
+++ b/HumbleEngine.Tests/Core/TextInputTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using Silk.NET.Input;
+
+namespace HumbleEngine.Tests;
+
+[TestFixture]
+public class TextInputTests
+{
+    private TextInput _input = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _input = new TextInput();
+        _input.Init();
+    }
+
+    [Test]
+    public void IsFocusable_IsTrue()
+        => Assert.That(_input.IsFocusable, Is.True);
+
+    [Test]
+    public void OnKeyChar_AppendsCharacter()
+    {
+        _input.OnKeyChar('H');
+        _input.OnKeyChar('i');
+
+        Assert.That(_input.Text.Value, Is.EqualTo("Hi"));
+    }
+
+    [Test]
+    public void OnKeyDown_Backspace_RemovesLastCharacter()
+    {
+        _input.Text.Value = "Hello";
+        _input.OnKeyDown(Key.Backspace);
+
+        Assert.That(_input.Text.Value, Is.EqualTo("Hell"));
+    }
+
+    [Test]
+    public void OnKeyDown_Backspace_OnEmptyText_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() => _input.OnKeyDown(Key.Backspace));
+        Assert.That(_input.Text.Value, Is.EqualTo(""));
+    }
+
+    [Test]
+    public void OnFocusGained_SetsFocusedState()
+    {
+        _input.OnFocusGained();
+
+        Assert.That(_input.Dirty, Is.Not.EqualTo(DirtyLevel.None));
+    }
+
+    [Test]
+    public void OnFocusLost_ClearsFocusedState()
+    {
+        _input.OnFocusGained();
+        _input.ClearDirty();
+
+        _input.OnFocusLost();
+
+        Assert.That(_input.Dirty, Is.Not.EqualTo(DirtyLevel.None));
+    }
+}

--- a/HumbleEngine.Tests/Mvvm/LoginScreen.cs
+++ b/HumbleEngine.Tests/Mvvm/LoginScreen.cs
@@ -16,11 +16,12 @@ public class LoginScreen : Node
         var titleLabel = new Label();
         titleLabel.Text.Value = "Votre nom :";
 
-        var col = new Column();
-        AddChild(col);
-        col.AddChild(titleLabel);
-        col.AddChild(_input);
-        col.AddChild(_greetingLabel);
+        AddChild(new Column
+        {
+            titleLabel,
+            _input,
+            _greetingLabel
+        });
 
         // Two-way : _input.Text ↔ Vm.Username
         _input.Text.BindFrom(Vm.Username);

--- a/HumbleEngine.Tests/Mvvm/LoginScreen.cs
+++ b/HumbleEngine.Tests/Mvvm/LoginScreen.cs
@@ -1,0 +1,32 @@
+namespace HumbleEngine.Tests;
+
+public class LoginScreen : Node
+{
+    public  readonly LoginViewModel Vm             = new();
+    private readonly TextInput      _input         = new();
+    private readonly Label          _greetingLabel = new();
+
+    public TextInput Input         => _input;
+    public Label     GreetingLabel => _greetingLabel;
+
+    public override void Init()
+    {
+        base.Init();
+
+        var titleLabel = new Label();
+        titleLabel.Text.Value = "Votre nom :";
+
+        var col = new Column();
+        AddChild(col);
+        col.AddChild(titleLabel);
+        col.AddChild(_input);
+        col.AddChild(_greetingLabel);
+
+        // Two-way : _input.Text ↔ Vm.Username
+        _input.Text.BindFrom(Vm.Username);
+        Vm.Username.BindFrom(_input.Text);
+
+        // One-way : Vm.Greeting → _greetingLabel.Text
+        _greetingLabel.Text.BindFrom(Vm.Greeting);
+    }
+}

--- a/HumbleEngine.Tests/Mvvm/LoginViewModel.cs
+++ b/HumbleEngine.Tests/Mvvm/LoginViewModel.cs
@@ -1,0 +1,15 @@
+namespace HumbleEngine.Tests;
+
+public class LoginViewModel
+{
+    public ReactiveProperty<string> Username = new("");
+    public ReactiveProperty<string> Greeting = new("Entrez votre nom.");
+
+    public LoginViewModel()
+    {
+        Username.Connect(name =>
+            Greeting.Value = string.IsNullOrEmpty(name)
+                ? "Entrez votre nom."
+                : $"Bonjour, {name} !");
+    }
+}

--- a/HumbleEngine.Tests/Mvvm/MvvmTests.cs
+++ b/HumbleEngine.Tests/Mvvm/MvvmTests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using Silk.NET.Input;
+
+namespace HumbleEngine.Tests;
+
+[TestFixture]
+public class MvvmTests
+{
+    private LoginScreen _screen = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _screen = new LoginScreen();
+        _screen.Init();
+    }
+
+    [Test]
+    public void Typing_UpdatesViewModel()
+    {
+        _screen.Input.OnKeyChar('O');
+        _screen.Input.OnKeyChar('m');
+        _screen.Input.OnKeyChar('a');
+        _screen.Input.OnKeyChar('r');
+
+        Assert.That(_screen.Vm.Username.Value, Is.EqualTo("Omar"));
+    }
+
+    [Test]
+    public void ViewModelChange_UpdatesInput()
+    {
+        _screen.Vm.Username.Value = "Omar";
+
+        Assert.That(_screen.Input.Text.Value, Is.EqualTo("Omar"));
+    }
+
+    [Test]
+    public void Typing_UpdatesGreetingLabel()
+    {
+        _screen.Input.OnKeyChar('O');
+        _screen.Input.OnKeyChar('m');
+        _screen.Input.OnKeyChar('a');
+        _screen.Input.OnKeyChar('r');
+
+        Assert.That(_screen.GreetingLabel.Text.Value, Is.EqualTo("Bonjour, Omar !"));
+    }
+
+    [Test]
+    public void ClearingInput_ResetsGreeting()
+    {
+        _screen.Vm.Username.Value = "Omar";
+        _screen.Input.OnKeyDown(Key.Backspace);
+        _screen.Input.OnKeyDown(Key.Backspace);
+        _screen.Input.OnKeyDown(Key.Backspace);
+        _screen.Input.OnKeyDown(Key.Backspace);
+
+        Assert.That(_screen.GreetingLabel.Text.Value, Is.EqualTo("Entrez votre nom."));
+    }
+}

--- a/HumbleEngine/Application.cs
+++ b/HumbleEngine/Application.cs
@@ -15,6 +15,15 @@ public sealed class Application : IDisposable
 
     private List<Node> _hoveredPath = new();
     private Node?      _pressedNode;
+    private Node?      _focusedNode;
+
+    public void SetFocus(Node? node)
+    {
+        if (_focusedNode == node) return;
+        _focusedNode?.OnFocusLost();
+        _focusedNode = node;
+        _focusedNode?.OnFocusGained();
+    }
 
     public Node? Root { get; set; }
 
@@ -68,6 +77,12 @@ public sealed class Application : IDisposable
             mouse.MouseMove += OnMouseMoved;
             mouse.MouseDown += OnMousePressed;
             mouse.MouseUp   += OnMouseReleased;
+        }
+        if (_inputContext.Keyboards.Count > 0)
+        {
+            var keyboard = _inputContext.Keyboards[0];
+            keyboard.KeyChar += OnKeyChar;
+            keyboard.KeyDown += OnKeyDown;
         }
 
         Root?.Init();
@@ -134,6 +149,12 @@ public sealed class Application : IDisposable
 
         _pressedNode = null;
     }
+
+    private void OnKeyChar(IKeyboard keyboard, char character)
+        => _focusedNode?.OnKeyChar(character);
+
+    private void OnKeyDown(IKeyboard keyboard, Key key, int scancode)
+        => _focusedNode?.OnKeyDown(key);
 
     private void OnUpdate(double delta) => Root?.Update((float)delta);
 

--- a/HumbleEngine/Application.cs
+++ b/HumbleEngine/Application.cs
@@ -136,6 +136,9 @@ public sealed class Application : IDisposable
 
         _pressedNode = HitTest.FirstInteractive(_hoveredPath);
         _pressedNode?.OnMouseDown();
+
+        if (_pressedNode is { IsFocusable: true })
+            SetFocus(_pressedNode);
     }
 
     private void OnMouseReleased(IMouse mouse, MouseButton button)

--- a/HumbleEngine/Nodes/TextInput.cs
+++ b/HumbleEngine/Nodes/TextInput.cs
@@ -1,0 +1,53 @@
+using Silk.NET.Input;
+using SkiaSharp;
+
+namespace HumbleEngine;
+
+public class TextInput : Node
+{
+    private const float PaddingX = 12f;
+    private const float PaddingY = 6f;
+
+    public ReactiveProperty<string> Text        = new("");
+    public ReactiveProperty<string> Placeholder = new("...");
+    public ReactiveProperty<float>  FontSize    = new(16f);
+
+    private bool _isFocused;
+
+    public override HitTestFilter MouseFilter => HitTestFilter.Stop;
+    public override bool IsFocusable => true;
+
+    public override void Init()
+    {
+        base.Init();
+        Text.Connect(_        => MarkLayoutDirty());
+        Placeholder.Connect(_ => MarkLayoutDirty());
+        FontSize.Connect(_    => MarkLayoutDirty());
+    }
+
+    public override void OnFocusGained() { _isFocused = true;  MarkPaintDirty(); }
+    public override void OnFocusLost()   { _isFocused = false; MarkPaintDirty(); }
+
+    public override void OnKeyChar(char c)
+    {
+        Text.Value += c;
+    }
+
+    public override void OnKeyDown(Key key)
+    {
+        if (key == Key.Backspace && Text.Value.Length > 0)
+            Text.Value = Text.Value[..^1];
+    }
+
+    protected override RenderDescription RenderContent()
+    {
+        var borderColor = _isFocused ? new SKColor(70, 130, 180) : new SKColor(180, 180, 180);
+        var textColor   = Text.Value.Length > 0 ? SKColors.Black : new SKColor(160, 160, 160);
+        var displayed   = Text.Value.Length > 0 ? Text.Value : Placeholder.Value;
+
+        return new Box
+        {
+            new Span(displayed).Color(textColor).FontSize(FontSize.Value)
+        }.Color(SKColors.White).Border(borderColor, 1.5f).Padding(PaddingX, PaddingY);
+    }
+}

--- a/HumbleEngine/Rendering/RenderElements/Box/Box.cs
+++ b/HumbleEngine/Rendering/RenderElements/Box/Box.cs
@@ -13,8 +13,9 @@ public struct Box : ICompositeRenderElement
 
     public LayoutData Layout { get => _layout; set => _layout = value; }
 
-    public Box Color(SKColor color)       { _boxData = _boxData with { BackgroundColor = color }; return this; }
-    public Box CornerRadius(float radius) { _boxData = _boxData with { CornerRadius    = radius }; return this; }
+    public Box Color(SKColor color)                      { _boxData = _boxData with { BackgroundColor = color };                              return this; }
+    public Box CornerRadius(float radius)                { _boxData = _boxData with { CornerRadius    = radius };                             return this; }
+    public Box Border(SKColor color, float width = 1f)   { _boxData = _boxData with { BorderColor = color, BorderWidth = width };             return this; }
 
     public void Add(RenderDescription child)
     {

--- a/HumbleEngine/Rendering/RenderElements/Box/BoxData.cs
+++ b/HumbleEngine/Rendering/RenderElements/Box/BoxData.cs
@@ -6,4 +6,6 @@ public readonly struct BoxData
 {
     public SKColor BackgroundColor { get; init; }
     public float   CornerRadius    { get; init; }
+    public SKColor BorderColor     { get; init; }
+    public float   BorderWidth     { get; init; }
 }

--- a/HumbleEngine/Rendering/RenderTree.cs
+++ b/HumbleEngine/Rendering/RenderTree.cs
@@ -200,13 +200,25 @@ public sealed class RenderTree
 
     private static void PaintBox(SKCanvas canvas, Rect bounds, BoxData data)
     {
-        using var paint = new SKPaint { Color = data.BackgroundColor, IsAntialias = true };
+        using var paint = new SKPaint { IsAntialias = true };
         var rect = new SKRect(bounds.X, bounds.Y, bounds.X + bounds.Width, bounds.Y + bounds.Height);
 
+        paint.Color = data.BackgroundColor;
         if (data.CornerRadius > 0)
             canvas.DrawRoundRect(rect, data.CornerRadius, data.CornerRadius, paint);
         else
             canvas.DrawRect(rect, paint);
+
+        if (data.BorderWidth > 0)
+        {
+            paint.Color       = data.BorderColor;
+            paint.Style       = SKPaintStyle.Stroke;
+            paint.StrokeWidth = data.BorderWidth;
+            if (data.CornerRadius > 0)
+                canvas.DrawRoundRect(rect, data.CornerRadius, data.CornerRadius, paint);
+            else
+                canvas.DrawRect(rect, paint);
+        }
     }
 
     private static void PaintSpan(SKCanvas canvas, Rect bounds, SpanData data)

--- a/HumbleEngine/Scene/Node.cs
+++ b/HumbleEngine/Scene/Node.cs
@@ -1,8 +1,9 @@
+using System.Collections;
 using Silk.NET.Input;
 
 namespace HumbleEngine;
 
-public abstract class Node
+public abstract class Node : IEnumerable<Node>
 {
     private readonly List<Node> _children = new();
 
@@ -22,6 +23,11 @@ public abstract class Node
     public void MarkLogicDirty()  => MarkDirty(DirtyLevel.Logic);
 
     internal void ClearDirty() => Dirty = DirtyLevel.None;
+
+    // Requis pour la syntaxe collection initializer : new Column { child1, child2 }
+    public void Add(Node child) => AddChild(child);
+    public IEnumerator<Node> GetEnumerator() => _children.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()  => GetEnumerator();
 
     public void AddChild(Node child)
     {

--- a/HumbleEngine/Scene/Node.cs
+++ b/HumbleEngine/Scene/Node.cs
@@ -55,6 +55,7 @@ public abstract class Node
     }
 
     public virtual HitTestFilter MouseFilter => HitTestFilter.Ignore;
+    public virtual bool IsFocusable => false;
 
     public virtual void OnMouseEnter() { }
     public virtual void OnMouseLeave() { }

--- a/HumbleEngine/Scene/Node.cs
+++ b/HumbleEngine/Scene/Node.cs
@@ -1,3 +1,5 @@
+using Silk.NET.Input;
+
 namespace HumbleEngine;
 
 public abstract class Node
@@ -59,6 +61,11 @@ public abstract class Node
     public virtual void OnMouseDown()  { }
     public virtual void OnMouseUp()    { }
     public virtual void OnClick()      { }
+
+    public virtual void OnFocusGained()         { }
+    public virtual void OnFocusLost()           { }
+    public virtual void OnKeyChar(char c)       { }
+    public virtual void OnKeyDown(Key key)      { }
 
     public Rect ComputedBounds { get; internal set; }
 

--- a/docs/Indexes/project-status.md
+++ b/docs/Indexes/project-status.md
@@ -17,18 +17,21 @@ HumbleEngine/
 │   │                    IRenderElement, ICompositeRenderElement, RenderElementExtensions
 │   └── RenderElements/
 │       ├── Span/        Span, SpanData
-│       ├── Box/         Box, BoxData
+│       ├── Box/         Box, BoxData (BackgroundColor, CornerRadius, BorderColor, BorderWidth)
 │       ├── VLayout/     VLayout (vertical, XXXLayout = pas de visuel)
 │       └── HLayout/     HLayout (horizontal)
 └── Nodes/
     ├── Label.cs
     ├── Button.cs
+    ├── TextInput.cs
     └── Layout/          Column, Row
 
 HumbleEngine.Tests/
 ├── Core/                NodeTests, SignalTests, ReactivePropertyTests, ReactiveCollectionTests
+│                        TextInputTests
 ├── Rendering/           BoxConstraintsTests, LayoutTests
-└── Input/               HitTestTests
+├── Input/               HitTestTests
+└── Mvvm/                LoginViewModel, LoginScreen, MvvmTests
 ```
 
 Tous les types dans `namespace HumbleEngine;`
@@ -42,9 +45,9 @@ Tous les types dans `namespace HumbleEngine;`
 | 1 + 2 | Primitives + Premier rendu | ✅ | `docs/Status/phase-1-2.md` |
 | 3 | Input system, HitTest, Button | ✅ | `docs/Status/phase-3.md` |
 | 4 | Layout pivot, Column/Row, nomenclature | ✅ | `docs/Status/phase-4.md` |
-| 5 | TextInput, premier écran MVVM | ⬜ | |
+| 5 | TextInput, premier écran MVVM | ✅ | `docs/Status/phase-5.md` |
 
-Tests : **72/72** ✅
+Tests : **82/82** ✅
 
 ---
 

--- a/docs/Status/phase-5.md
+++ b/docs/Status/phase-5.md
@@ -1,0 +1,74 @@
+# Phase 5 — TextInput + premier écran MVVM ✅
+
+Tests : 82/82 ✅
+
+---
+
+## Infrastructure clavier + focus
+
+`Application` : `_focusedNode`, `SetFocus()`, dispatch `OnKeyChar`/`OnKeyDown` vers le nœud focalisé.
+Focus déclenché automatiquement dans `OnMousePressed` si `node.IsFocusable == true`.
+
+```csharp
+// Node
+public virtual bool IsFocusable => false;
+public virtual void OnFocusGained() { }
+public virtual void OnFocusLost()   { }
+public virtual void OnKeyChar(char c)  { }
+public virtual void OnKeyDown(Key key) { }
+```
+
+---
+
+## TextInput
+
+```csharp
+public class TextInput : Node
+{
+    public ReactiveProperty<string> Text        = new("");
+    public ReactiveProperty<string> Placeholder = new("...");
+    public ReactiveProperty<float>  FontSize    = new(16f);
+
+    public override HitTestFilter MouseFilter => HitTestFilter.Stop;
+    public override bool IsFocusable => true;
+
+    public override void OnKeyChar(char c)   => Text.Value += c;
+    public override void OnKeyDown(Key key)
+    {
+        if (key == Key.Backspace && Text.Value.Length > 0)
+            Text.Value = Text.Value[..^1];
+    }
+    // RenderContent : Box [ Span ] avec bordure bleue si focalisé
+}
+```
+
+---
+
+## Box.Border
+
+`BoxData` : `BorderColor` + `BorderWidth`.
+`Box.Border(SKColor color, float width = 1f)`.
+`RenderTree.PaintBox` : second draw call `SKPaintStyle.Stroke` si `BorderWidth > 0`.
+
+---
+
+## Premier écran MVVM
+
+**Pattern :** ViewModel = plain C# + `ReactiveProperty<T>`. Node = View. Zéro dépendance croisée.
+
+```csharp
+// Two-way binding
+input.Text.BindFrom(vm.Username);
+vm.Username.BindFrom(input.Text);
+
+// One-way binding
+greetingLabel.Text.BindFrom(vm.Greeting);
+```
+
+**Chaîne réactive validée :** `OnKeyChar` → `TextInput.Text` → `Vm.Username` → `Vm.Greeting` → `Label.Text`
+
+---
+
+## HitTest sub-node (future)
+
+Noté dans `docs/future-ideas.md` : HitTest au niveau `RenderElement` pour les zones interactives sub-node (style Flutter `RenderBox.hitTest`).

--- a/docs/future-ideas.md
+++ b/docs/future-ideas.md
@@ -12,3 +12,13 @@
 **Bénéfice attendu :** Éliminer les copies de struct pendant `Flatten()`, meilleure localité cache sur l'ensemble des données de rendu.
 
 **Pourquoi pas maintenant :** `RenderDescription` est déjà transient (stack), les tableaux typés actuels sont déjà cache-friendly, et le vrai bottleneck est SkiaSharp (DrawText, DrawRect, OpenGL). À profiler avant d'implémenter.
+
+---
+
+## HitTest au niveau RenderElement
+
+**Idée :** Faire descendre le HitTest dans le RenderTree plutôt que dans le Node tree. Chaque `IRenderElement` porte un `MouseFilter`. HitTest.Find() parcourt le render tree et remonte l'élément touché + son `Owner` (Node).
+
+**Bénéfice attendu :** Précision sub-node — zones non-interactives à l'intérieur d'un Node (ex. padding non-cliquable d'un TextInput, label non-cliquable dans un widget composite). Pattern identique à Flutter (RenderBox.hitTest).
+
+**Pourquoi pas maintenant :** Pour Phase 5, un TextInput répond sur toute sa surface (`ComputedBounds`) — comportement UX correct. Ce besoin n'émerge que pour des widgets composites complexes. À implémenter quand un cas concret le justifie.


### PR DESCRIPTION
## Résumé

- **Step 1** — Infrastructure clavier + focus : `Node.OnFocusGained/Lost`, `OnKeyChar`, `OnKeyDown` ; `Application.SetFocus()`, dispatch clavier vers le nœud focalisé
- **Step 2a** — `Node.IsFocusable` (défaut `false`) ; focus automatique au `mousedown` dans `Application`
- **Step 2b** — `TextInput` node : saisie, Backspace, placeholder, bordure focus/blur ; `Box.Border(color, width)` + `PaintBox` Stroke
- **Step 2c** — 6 tests `TextInput` (keychar, backspace, empty, focusable, focus gained/lost)
- **Step 3** — `LoginViewModel` + `LoginScreen` : binding two-way `TextInput.Text ↔ Vm.Username`, one-way `Vm.Greeting → Label.Text` ; 4 tests chaîne réactive complète

## Tests

82/82 ✅

## Plan de test

- [ ] 82 tests passent (`dotnet test`)
- [ ] `TextInput` répond aux frappes clavier et Backspace
- [ ] Focus visuel (bordure bleue) au clic, grisée au blur
- [ ] Placeholder affiché quand le champ est vide
- [ ] Chaîne MVVM : typing → ViewModel → Label mis à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)